### PR TITLE
Sync gateway README and DESIGN docs with main behavior

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -18,9 +18,9 @@ gtw/
     CommanderFactory.js      ← Factory: cmd string → Commander instance
     OnCommand.js            ← Set workdir + repo + inject phase directive
     NewCommand.js           ← Auto-generate issue draft from session (AI)
-    FixCommand.js           ← Create fix branch
-    PrCommand.js            ← Push branch + prepare PR body
-    PushCommand.js          ← git add → commit → push
+    FixCommand.js           ← Claim issue, create branch, inject directive, subagent fix flow
+    PrCommand.js            ← Generate PR title/body draft (pendingPr)
+    PushCommand.js          ← Generate commit message draft (pendingCommit)
     ConfirmCommand.js       ← Execute pending actions (issue/PR creation)
     ReviewCommand.js        ← Claim + review + verdict PR
     IssueCommand.js         ← List open issues
@@ -122,6 +122,70 @@ That's it — index.js does not change.
 /gtw new              → auto-generate issue draft from chat via AI (no args)
 /gtw confirm          → create issue from wip.issue.title/body + wip.repo
 ```
+
+## `/gtw fix` — Subagent-Driven Fix Flow
+
+The `/gtw fix` command automates the entire fix lifecycle via a subagent, with explicit safety checkpoints.
+
+### State Transitions
+
+```
+unclaimed issue
+    │
+    │ /gtw fix <issue_id>
+    ▼
+claimed ──────────────── gtw/wip label applied to GitHub issue
+    │                        (conflict avoidance: one fix at a time per issue)
+    │
+    ▼
+wip branch created ──── git checkout -b fix/<normalized-title>
+    │
+    ▼
+fix-spawned ─────────── Directive injected into main session JSONL
+    │                        (triggers subagent in the main session)
+    │
+    ▼
+subagent running ────── Main session spawns coding subagent
+    │                        Subagent: explores code, makes changes, commits, pushes
+    │
+    ▼
+pendingCommit ───────── wip.json stores pendingCommit after subagent push
+    │
+    │ /gtw confirm (pendingCommit branch)
+    ▼
+pushed ───────────────── git push -u origin <branch>
+    │
+    ▼
+unclaimed ────────────── gtw/wip label removed from GitHub issue
+    │
+    ▼
+(optional) /gtw pr → pendingPr → /gtw confirm → PR created
+```
+
+### Step-by-Step Breakdown
+
+1. **Claim issue**: POST `gtw/wip` label to GitHub issue. Aborts if label already present (another fix in progress).
+2. **Git setup**: `git fetch origin`, checkout default branch, `git pull --rebase`, create uniquely-named branch `fix/<normalized-title>`.
+3. **Inject directive**: Append a structured directive message to the main session JSONL. This directive contains step-by-step instructions for the main session agent to: spawn a coding subagent, wait for it, run `git add/commit/push`, update `wip.json` with fix status, and remove the `gtw/wip` label.
+4. **Return to user**: The command returns immediately after injecting the directive. The actual fix work happens asynchronously in the main session.
+5. **Cleanup**: Regardless of fix outcome (success, no-changes, or failure), the `gtw/wip` label is removed from the GitHub issue.
+
+### Why the Two-Step Confirm Model?
+
+The two-step pattern (`pendingCommit` → `/gtw confirm`) and the two-step PR flow (`pendingPr` → `/gtw confirm`) exist for safety:
+
+- **No accidental API calls**: No branch is pushed and no PR is created without an explicit confirm step.
+- **Human reviewable**: The generated commit message and PR title/body are displayed before execution, allowing the user to catch LLM hallucinations.
+- **Retry on failure**: If the GitHub API call fails, the pending draft is preserved and the user can retry after fixing the issue.
+
+`pendingCommit` and `pendingPr` are stored in `wip.json` under the `~/.openclaw/gtw/` directory.
+
+### FixCommand Implementation Notes
+
+- `claimIssue()` / `unclaimIssue()` use the GitHub Issues API labels endpoint.
+- `injectFixDirective()` appends a JSONL entry to the main session file (found via `sessions.json` lookup).
+- `wasInjected()` checks if a directive for this issue is already in the session (prevents double-injection on re-runs).
+- wip.json stores `latestFixStatus` (`fix-spawned` | `success` | `no-changes` | `failure`), `latestFixBranch`, `latestFixCommitTitle`, `latestFixPushedAt`.
 
 ## Notes for AI Agents
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,29 @@
+# gtw — Notes & Changelog
+
+## 2026-03-31 — Documentation Sync
+
+**Issue:** #19 — fix: sync gtw docs with main behavior
+
+Documentation (README.md and DESIGN.md) was out of sync with the actual implementation on `main` as of 2026-03-31. Multiple user-visible commands had different semantics in docs vs code.
+
+### What was fixed
+
+**README.md:**
+- `/gtw push`: Removed incorrect claim that it "executes directly, no confirm needed". Now correctly documents the two-step `pendingCommit` → `/gtw confirm` flow in both prose and example workflows.
+- `/gtw fix`: Replaced short description with full subagent-driven flow (claim issue → gtw/wip label → fetch → create branch → inject directive → subagent fixes → pendingCommit → `/gtw confirm` → unclaim/remove label). Example workflow updated.
+- `/gtw pr`: Now clearly documents the `pendingPr` draft → `/gtw confirm` two-step flow and the branch push vs PR creation separation.
+- `/gtw review`: Documents the two-call verdict flow: first call claims PR (`eyes` comment + checklist), second call with `approved|changes` finalizes (posts verdict, submits GitHub review, releases claim). Added review workflow example.
+- Standard workflow examples updated to show correct order: `/gtw fix` → push → confirm → pr → confirm.
+
+**DESIGN.md:**
+- Rewrote `/gtw fix` section to reflect the current main implementation: full subagent automation, gtw/wip label lifecycle, directive injection, state transitions (unclaimed → claimed → wip branch → fix-spawned → subagent running → pendingCommit → pushed → unclaimed).
+- Updated file structure list to accurately describe FixCommand, PrCommand, and PushCommand roles.
+- Added notes on why the two-step confirm model exists (safety, human reviewability, retry on failure).
+- Documented where pendingCommit and pendingPr are stored (`~/.openclaw/gtw/wip.json`).
+
+**Added:**
+- `NOTES.md` — this changelog entry documenting the sync and date (2026-03-31).
+
+### Reference
+
+Main merge that introduced subagent-driven `/gtw fix`: `fix/subagent-driven-fix` branch merged to main (2026-03-31).

--- a/README.md
+++ b/README.md
@@ -44,21 +44,25 @@ This registers the `/gtw` slash command and enables the plugin. Gateway hot-relo
 ### Git Operations
 
 ```
-/gtw fix <issue_id>     Fetch issue, derive branch name, checkout, ready for coding
-/gtw push               Stage → auto-commit (conventional format) → push (executes directly, no confirm needed)
-/gtw pr [issue_id]      Generate PR title/body via LLM from commit diff, save as pending PR draft
+/gtw fix <issue_id>     Claim issue (add gtw/wip label), fetch issue, derive branch name, create branch,
+                          inject directive to trigger subagent, subagent fixes automatically, creates
+                          pendingCommit, requires /gtw confirm to push, then unclaims (removes label)
+/gtw push               Stage → auto-commit (conventional format) → generate commit draft → save as pendingCommit
+                          (two-step: run /gtw confirm to actually push)
+/gtw pr [issue_id]      Generate PR title/body via LLM from commit diff, save as pendingPr draft
                           — /gtw pr (no args): uses current branch; never reads wip.json
                           — /gtw pr <issue_id>: derives branch from issue title (same as /gtw fix)
                             If remote branch exists → checks out and hard-resets to it.
                             If local branch exists but remote missing → checks out and prompts to run /gtw push.
                             If neither exists → uses current branch.
+                          (two-step: run /gtw confirm to actually create the PR)
 ```
 
 ### Review
 
 ```
-/gtw review             Find and claim earliest unclaimed PR
-/gtw review #<pr> approved   # or changes
+/gtw review             Claim earliest unclaimed PR (adds eyes comment with review checklist)
+/gtw review #<pr> approved   # or changes   Finalize review — labels PR, posts verdict comment, releases claim
 ```
 
 ### Config
@@ -107,16 +111,32 @@ You: /gtw new
    ## Acceptance Criteria
    ...
 
-You: /gtw fix login-bug
-→ 🌿 Created and checked out new branch fix/login-bug
+You: /gtw fix 42
+→ 🌿 Fix workflow started
+   Issue: #42
+   Title: fix: handle null pointer in auth
+   Branch: fix/handle-null-pointer
+   ⏳ Subagent spawned — the main session will now:
+   1. Spawn coding subagent to fix the issue
+   2. Wait for subagent to finish
+   3. Run push + confirm automatically
+   (gtw/wip label is applied to issue #42)
 
 You: /gtw push
-→ 📦 Committed and pushed (executes directly, no confirm needed)
+→ 🔍 Commit draft — run /gtw confirm to push
+   📝 Commit Message: fix(auth): handle null pointer in auth
+   📊 Changes: +10 -2
+   Run /gtw confirm to commit and push.
+
+You: /gtw confirm
+→ 📦 Committed and pushed
+   Branch: fix/handle-null-pointer
+   (gtw/wip label removed from issue #42)
 
 You: /gtw pr
 → 🔍 PR draft — run /gtw confirm to create PR
    📝 Title: fix: handle null pointer in auth
-   🌿 Branch: fix/login-bug → main
+   🌿 Branch: fix/handle-null-pointer → main
 
 You: /gtw confirm
 → ✅ PR #42 created
@@ -130,28 +150,108 @@ You: /gtw pr 13
 → 🔍 PR draft for issue #13 — run /gtw confirm to create PR
    📝 Title: fix: handle null pointer in auth
    🌿 Branch: fix/handle-null-pointer
-   ⚠️  Remote branch missing — please run /gtw push to publish this branch   Issue: #13 — handle null pointer in auth
+   ⚠️  Remote branch missing — please run /gtw push to publish this branch
+   Issue: #13 — handle null pointer in auth
+
 You: /gtw push
+→ 🔍 Commit draft — run /gtw confirm to push
+   📝 Commit Message: fix(auth): handle null pointer in auth
+   Run /gtw confirm to commit and push.
+
+You: /gtw confirm
 → 📦 Committed and pushed
+   Branch: fix/handle-null-pointer
 
 You: /gtw pr 13
 → 🔍 PR draft for issue #13 — run /gtw confirm to create PR
    📝 Title: fix: handle null pointer in auth
-   🌿 Branch: fix/handle-null-pointer   Issue: #13 — handle null pointer in auth
+   🌿 Branch: fix/handle-null-pointer → main
+   Issue: #13 — handle null pointer in auth
 
 You: /gtw confirm
 → ✅ PR #42 created
    URL: https://github.com/owner/repo/pull/42
 ```
 
-**Phase directive:** `/gtw on` injects a "no code yet" message into the parent session so the agent stays in discussion mode until `/gtw confirm`.
-
-## State File
+### Review Workflow
 
 ```
-~/.openclaw/gtw/wip.json
-~/.openclaw/gtw/token.json
+You: /gtw review
+→ eyes Claimed PR #23: fix: handle null pointer
+   Linked Issue: handle null pointer in auth
+   Files changed (3):
+     - src/auth.js: +10 -2
+     - tests/auth.test.js: +5 -0
+   Review the diff against the issue requirements, then call:
+   /gtw review #23 approved   # or changes
+
+You: /gtw review #23 approved
+→ ✅ PR #23 approved
+   Claim released, ready to merge
 ```
+
+**Two-call review verdict flow:**
+1. First call (`/gtw review` or `/gtw review #<pr>`): Claims the PR by adding an `eyes` comment with a review checklist. The PR is considered "in progress".
+2. Second call (with `approved` or `changes`): Finalizes the review — deletes the eyes comment, posts the verdict emoji, submits the GitHub review with the appropriate state (APPROVED or CHANGES_REQUESTED), and releases the claim.
+
+## State Files
+
+```
+~/.openclaw/gtw/wip.json       # Workdir, repo, pendingCommit, pendingPr, issue, branch
+~/.openclaw/gtw/token.json     # Cached gh CLI token
+~/.openclaw/gtw/config.json    # Custom AI model setting
+```
+
+### Two-Step Confirm Model
+
+All mutating operations (`/gtw push`, `/gtw pr`) follow a two-step pattern for safety:
+
+1. **Step 1 — Draft**: Command generates a draft (commit message or PR title/body) and saves it as `pendingCommit` or `pendingPr` in `wip.json`. Nothing is pushed or created yet.
+2. **Step 2 — Confirm**: `/gtw confirm` reads the pending draft and executes the actual GitHub API call (push or PR creation).
+
+This means every workflow that involves pushing or creating a PR will have a `→ /gtw confirm` step before the final success message.
+
+## Testing / Verification
+
+### End-to-End Checklist for Maintainers
+
+After any change to command logic, verify the affected flow:
+
+**`/gtw push` flow:**
+1. `cd <workdir> && echo "// test" >> README.md`
+2. `/gtw push` → should show "🔍 Commit draft — run /gtw confirm to push" (NOT immediate push)
+3. `cat ~/.openclaw/gtw/wip.json` → should contain `pendingCommit` with title/body/branch
+4. `/gtw confirm` → should show "📦 Committed and pushed"
+5. `git log --oneline -1` → should show the commit
+
+**`/gtw fix` flow:**
+1. `/gtw fix 13` → should claim issue (gtw/wip label appears on GitHub), create branch
+2. After subagent completes: `git log --oneline` → should have fix commits
+3. `/gtw confirm` → should push the branch
+4. GitHub issue #13 → gtw/wip label should be removed
+
+**`/gtw pr` flow:**
+1. Ensure branch is pushed and on the correct branch
+2. `/gtw pr` → should show "🔍 PR draft — run /gtw confirm to create PR"
+3. `cat ~/.openclaw/gtw/wip.json` → should contain `pendingPr` with title/body
+4. `/gtw confirm` → should create PR on GitHub and show URL
+5. `cat ~/.openclaw/gtw/wip.json` → `pendingPr` should be cleared, `pr` should be set
+
+**`/gtw review` flow:**
+1. `/gtw review` → should claim an unclaimed PR (eyes comment appears)
+2. `/gtw review #<pr> approved` → should post approved comment and submit GitHub review
+3. PR page → should show review state as "Approved"
+
+### What to Observe
+
+| Flow | Check |
+|------|-------|
+| `pendingCommit` created | `wip.json` contains `pendingCommit` after `/gtw push` |
+| `pendingPr` created | `wip.json` contains `pendingPr` after `/gtw pr` |
+| `gtw/wip` label applied | GitHub issue shows `gtw/wip` label after `/gtw fix` |
+| `gtw/wip` label removed | GitHub issue loses `gtw/wip` label after fix flow completes |
+| Eyes comment posted | GitHub PR shows `eyes` comment from your login |
+| Review verdict posted | GitHub PR shows `approved` or `changes` emoji comment |
 
 ## Architecture
 


### PR DESCRIPTION
What changed:
- Synchronized README and DESIGN documents with the current behavior on main. Updated examples, configuration option descriptions, and architecture notes so the docs reflect the implemented gateway behavior.

Why it changed:
- Documentation had diverged from the code on main, causing confusion for contributors and users. This change aligns docs with implementation to reduce mismatch and onboarding friction.

How to test:
- Review the updated README and DESIGN files for correctness.
- Build/preview the docs locally (repo doc build or mkdocs) to ensure rendering is correct.
- Optionally start the gateway and validate that the documented configuration snippets and examples behave as described in the updated docs.

---
_Generated by gtw_