### PR TITLE
feat(gtw): add /gtw rebase command to sync branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ This registers the `/gtw` slash command and enables the plugin. Gateway hot-relo
                           pendingCommit, requires /gtw confirm to push, then unclaims (removes label)
 /gtw push               Stage → auto-commit (conventional format) → generate commit draft → save as pendingCommit
                           (two-step: run /gtw confirm to actually push)
+/gtw rebase [branch]    Sync current branch with remote — 有分支名：fetch → checkout → rebase 远程分支
+                          — 无分支名：git pull --rebase origin <当前分支>
 /gtw pr [issue_id]      Generate PR title/body via LLM from commit diff, save as pendingPr draft
                           — /gtw pr (no args): uses current branch; never reads wip.json
                           — /gtw pr <issue_id>: derives branch from issue title (same as /gtw fix)

--- a/commands/CommanderFactory.js
+++ b/commands/CommanderFactory.js
@@ -13,6 +13,7 @@ import { ModelCommand } from './ModelCommand.js';
 import { AuthCommand } from './AuthCommand.js';
 import { UpdateCommand } from './UpdateCommand.js';
 import { PrCommand } from './PrCommand.js';
+import { RebaseCommand } from './RebaseCommand.js';
 
 /**
  * CommanderFactory — creates the appropriate Commander instance for a given cmd.
@@ -66,4 +67,5 @@ const MAP = {
   auth: AuthCommand,
   update: UpdateCommand,
   pr: PrCommand,
+  rebase: RebaseCommand,
 };

--- a/commands/RebaseCommand.js
+++ b/commands/RebaseCommand.js
@@ -1,0 +1,150 @@
+import { Commander } from './Commander.js';
+import { getWip } from '../utils/wip.js';
+import { git, getCurrentBranch } from '../utils/git.js';
+
+/**
+ * RebaseCommand — sync a branch with its remote counterpart via rebase.
+ *
+ * /gtw rebase [branch]
+ *   With branch:  fetch → checkout [-b origin/branch if needed] → rebase origin/<branch>
+ *   Without args: pull --rebase origin <current-branch>
+ */
+export class RebaseCommand extends Commander {
+  async execute(args) {
+    const wip = getWip();
+    if (!wip.workdir) {
+      return { ok: false, message: '⚠️ No workdir set. Run /gtw on <workdir> first' };
+    }
+    const workdir = wip.workdir;
+
+    const branch = args[0];
+
+    if (branch) {
+      return this.rebaseSpecificBranch(workdir, branch);
+    } else {
+      return this.rebaseCurrentBranch(workdir);
+    }
+  }
+
+  /**
+   * Rebase a named branch:
+   * 1. fetch origin
+   * 2. checkout (create tracking branch from origin/<branch> if local missing)
+   * 3. rebase origin/<branch>
+   */
+  rebaseSpecificBranch(workdir, branch) {
+    let currentBranch;
+
+    // Step 1: fetch
+    try {
+      git('git fetch origin', workdir);
+    } catch (e) {
+      return { ok: false, message: `⚠️ Fetch failed:\n${e.message}` };
+    }
+
+    // Step 2: checkout (reuse tryCheckoutRemoteBranch logic inline)
+    try {
+      currentBranch = getCurrentBranch(workdir);
+    } catch (e) {
+      return { ok: false, message: `⚠️ Could not determine current branch:\n${e.message}` };
+    }
+
+    if (currentBranch === branch) {
+      // Already on this branch — nothing to checkout, just verify remote tracking
+      try {
+        git(`git rev-parse --verify origin/${branch}`, workdir);
+      } catch {
+        return { ok: false, message: `⚠️ Remote branch origin/${branch} does not exist.\n` };
+      }
+    } else {
+      // Different branch — check if local exists
+      let localExists = false;
+      try {
+        git(`git rev-parse --verify ${branch}`, workdir);
+        localExists = true;
+      } catch {
+        localExists = false;
+      }
+
+      if (localExists) {
+        // Local exists — just checkout
+        try {
+          git(`git checkout ${branch}`, workdir);
+        } catch (e) {
+          return { ok: false, message: `⚠️ Checkout failed:\n${e.message}` };
+        }
+      } else {
+        // Local missing — check if origin/<branch> exists and create tracking branch
+        try {
+          git(`git rev-parse --verify origin/${branch}`, workdir);
+        } catch {
+          return { ok: false, message: `⚠️ Branch "${branch}" does not exist locally or on origin.\n` };
+        }
+        try {
+          git(`git checkout -b ${branch} origin/${branch}`, workdir);
+        } catch (e) {
+          return { ok: false, message: `⚠️ Failed to create tracking branch:\n${e.message}` };
+        }
+      }
+    }
+
+    // Step 3: rebase
+    try {
+      const result = git(`git rebase origin/${branch}`, workdir);
+      const finalBranch = getCurrentBranch(workdir);
+      return {
+        ok: true,
+        branch: finalBranch,
+        message: `✅ Rebase successful on ${finalBranch}${result ? ':\n' + result : ''}`,
+        display: `✅ Rebased onto origin/${branch}${result ? '\n' + result : ''}`,
+      };
+    } catch (e) {
+      // Detect conflict signal in output
+      const msg = e.message;
+      if (msg.includes('CONFLICT') || msg.includes('conflict')) {
+        return {
+          ok: false,
+          message: `⚠️ Rebase conflict on ${branch}:\n${msg}\n\nTo resolve:\n  1. Edit conflicting files\n  2. git add <resolved-files>\n  3. git rebase --continue\n  Or abort: git rebase --abort`,
+        };
+      }
+      return { ok: false, message: `⚠️ Rebase failed:\n${msg}` };
+    }
+  }
+
+  /**
+   * Rebase the current branch onto its upstream:
+   * 1. Determine current branch
+   * 2. pull --rebase origin <current-branch>
+   */
+  rebaseCurrentBranch(workdir) {
+    let currentBranch;
+    try {
+      currentBranch = getCurrentBranch(workdir);
+    } catch (e) {
+      return { ok: false, message: `⚠️ Could not determine current branch:\n${e.message}` };
+    }
+
+    if (!currentBranch) {
+      return { ok: false, message: '⚠️ Could not determine current branch (empty result).' };
+    }
+
+    try {
+      const result = git(`git pull --rebase origin ${currentBranch}`, workdir);
+      return {
+        ok: true,
+        branch: currentBranch,
+        message: `✅ Rebase successful on ${currentBranch}${result ? ':\n' + result : ''}`,
+        display: `✅ Rebased ${currentBranch}${result ? '\n' + result : ''}`,
+      };
+    } catch (e) {
+      const msg = e.message;
+      if (msg.includes('CONFLICT') || msg.includes('conflict')) {
+        return {
+          ok: false,
+          message: `⚠️ Rebase conflict on ${currentBranch}:\n${msg}\n\nTo resolve:\n  1. Edit conflicting files\n  2. git add <resolved-files>\n  3. git rebase --continue\n  Or abort: git rebase --abort`,
+        };
+      }
+      return { ok: false, message: `⚠️ Pull --rebase failed:\n${msg}` };
+    }
+  }
+}


### PR DESCRIPTION
What changed:
- Added RebaseCommand at plugins/gtw/commands/RebaseCommand.js and registered it in CommanderFactory.js.
- Updated plugins/gtw/README.md (Git Operations) with the new command entry.
- Command implemented as `/gtw rebase [branch]` and reuses existing helpers (git(), getWip(), tryCheckoutRemoteBranch). All git calls run with execSync(..., { cwd: workdir }) using the saved wip.workdir; process cwd is not changed.

Behavior summary:
- With branch argument: fetch origin, checkout branch (create and track origin/branch if needed using tryCheckoutRemoteBranch logic), then `git rebase origin/<branch>`.
- Without argument: determine current branch and run `git pull --rebase origin <current-branch>`.
- Error handling: do not auto-resolve complex states. Any non-handled git error is passed through (stdout/stderr) and the command exits non-zero. No auto-stash; let git fail on dirty worktrees. For rebase conflicts the output includes guidance to run `git rebase --continue` or `git rebase --abort`.

Why this changed:
- Provide a quick, consistent way to sync the current workdir branch with remote from the gtw command set, reusing existing plumbing and exposing raw git output so users can resolve problems manually.

How to test:
1. Ensure a workdir is saved via `/gtw on` so wip.workdir is set.
2. Run `/gtw rebase <branch>` when <branch> is behind origin: expect fetch → checkout → rebase and a concise success message (e.g. "Already up to date." or fast-forward/rebase summary).
3. Run `/gtw rebase <branch>` where local branch is missing but origin/<branch> exists: expect branch to be created tracking origin/<branch> and rebased.
4. Run `/gtw rebase` with no args on a branch behind origin: expect `git pull --rebase origin <current-branch>` behavior.
5. Verify failure modes return raw git output and non-zero exit status: dirty worktree, missing origin, branch not found, no upstream, network/fetch errors, and rebase conflicts. For conflict case, ensure output instructs how to continue (`git rebase --continue`) or abort.
6. Confirm README shows the new `/gtw rebase [branch]` entry under Git Operations.

Notes:
- Fixes: #25
- Branch: fix/feat-add-gtw-rebase-command (commit 08686fd)