### PR TITLE
fix(import): use package-based import for openclaw plugin-sdk

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { definePluginEntry } from '/home/devin/.npm-global/lib/node_modules/openclaw/dist/plugin-sdk/plugin-entry.js';
+import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry';
 import { writeFileSync } from 'fs';
 import { CommanderFactory } from './commands/CommanderFactory.js';
 import { extractMessages, injectMessage } from './utils/session.js';


### PR DESCRIPTION
## What Changed
Changed the import statement for the openclaw plugin-sdk from a direct/relative import to use package-based import syntax.

## Why It Changed
This fix resolves an import resolution issue with the openclaw plugin-sdk. Using package-based imports ensures better compatibility and resolves potential path resolution problems.

## How to Test
1. Verify the application builds successfully
2. Run any existing tests to ensure functionality is preserved
3. Confirm the openclaw plugin-sdk is properly imported and accessible in the codebase

---
_Generated by gtw_