### PR TITLE
feat(labels): atomic mutually exclusive label system (#33)

### DIFF
--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -2,61 +2,10 @@ import { Commander } from './Commander.js';
 import { getWip, saveWip } from '../utils/wip.js';
 import { getConfig } from '../utils/config.js';
 import { getValidToken, apiRequest } from '../utils/api.js';
+import { setPrLabel } from '../utils/labels.js';
 
-const GTW_LABELS = ['gtw/ready', 'gtw/wip', 'gtw/lgtm', 'gtw/revise', 'gtw/stuck'];
 const CHECKLIST_ITEMS = ['Destructive', 'Out-of-scope'];
 const DEFAULT_MAX_ROUNDS = 5;
-
-// ---------------------------------------------------------------------------
-// Atomic label operations
-// ---------------------------------------------------------------------------
-
-/**
- * Atomically set a gtw label on a PR/issue: removes all other gtw/* labels first.
- * Returns { ok: true } on success.
- * Throws on failure (caller should abort).
- */
-export async function setGtwLabel(issueNumber, token, repo, targetLabel, isPR = true) {
-  if (!GTW_LABELS.includes(targetLabel)) {
-    throw new Error(`Invalid gtw label: ${targetLabel}. Must be one of: ${GTW_LABELS.join(', ')}`);
-  }
-
-  const endpointBase = isPR ? `/repos/${repo}/pulls/${issueNumber}` : `/repos/${repo}/issues/${issueNumber}`;
-
-  // Fetch current labels on the PR/issue
-  const currentLabels = await apiRequest('GET', `${endpointBase}/labels`, token);
-
-  // Identify which gtw/* labels are currently applied (excluding target)
-  const toRemove = currentLabels
-    .map((l) => l.name)
-    .filter((name) => GTW_LABELS.includes(name) && name !== targetLabel);
-
-  // Remove other gtw labels first
-  for (const label of toRemove) {
-    try {
-      await apiRequest('DELETE', `${endpointBase}/labels/${encodeURIComponent(label)}`, token);
-    } catch (e) {
-      // If removal fails (e.g. 404 race condition), abort — do not continue
-      if (e.message.includes('404') || e.message.includes('Label not found')) {
-        // Label already gone, that's fine
-      } else {
-        throw new Error(`Failed to remove label "${label}" from #${issueNumber}: ${e.message}. Aborting.`);
-      }
-    }
-  }
-
-  // Check if target label is already present (no-op for that label)
-  const alreadyHas = currentLabels.some((l) => l.name === targetLabel);
-  if (!alreadyHas) {
-    try {
-      await apiRequest('POST', `${endpointBase}/labels`, token, {
-        labels: [targetLabel],
-      });
-    } catch (e) {
-      throw new Error(`Failed to set label "${targetLabel}" on #${issueNumber}: ${e.message}. Aborting.`);
-    }
-  }
-}
 
 /**
  * Fetch PR details including diff summary and linked issue.
@@ -295,20 +244,20 @@ export class ReviewCommand extends Commander {
       };
     }
 
-    // Atomically claim the PR: remove other gtw labels, set gtw/wip
+    // Atomically claim the PR: remove other gtw labels, set gtw/wip.
+    // setPrLabel handles concurrency safety: re-checks labels and rolls back
+    // to gtw/ready if gtw/ready is still present (another runner won the race).
+    let preempted = false;
     try {
-      await setGtwLabel(prNum, token, repo, 'gtw/wip', true);
+      const result = await setPrLabel({ prNum, repo, token, isPR: true }, 'gtw/wip');
+      preempted = result.preempted;
     } catch (e) {
       return { ok: false, message: `⚠️ ${e.message}` };
     }
-
-    // Concurrency check: re-fetch PR to verify claim succeeded.
-    // If gtw/ready is still present, another runner claimed it — abort.
-    const prAfterClaim = await fetchPrDetails(prNum, token, repo);
-    if (prAfterClaim.pr.labels.some((l) => l.name === 'gtw/ready')) {
+    if (preempted) {
       return {
         ok: false,
-        message: `⚠️ PR #${prNum} was claimed by another runner (gtw/ready still present). Aborting.`,
+        message: `⚠️ PR #${prNum} was claimed by another runner (preemption detected). Aborting.`,
       };
     }
 
@@ -335,7 +284,7 @@ export class ReviewCommand extends Commander {
     // Check if max rounds exceeded
     if (round > maxRounds) {
       try {
-        await setGtwLabel(prNum, token, repo, 'gtw/stuck', true);
+        await setPrLabel({ prNum, repo, token, isPR: true }, 'gtw/stuck');
       } catch (e) {
         return { ok: false, message: `⚠️ ${e.message}` };
       }
@@ -377,7 +326,7 @@ export class ReviewCommand extends Commander {
 
       // Set gtw/lgtm
       try {
-        await setGtwLabel(prNum, token, repo, 'gtw/lgtm', true);
+        await setPrLabel({ prNum, repo, token, isPR: true }, 'gtw/lgtm');
       } catch (e) {
         return { ok: false, message: `⚠️ ${e.message}` };
       }
@@ -408,7 +357,7 @@ export class ReviewCommand extends Commander {
 
     // Apply gtw/revise (replaces gtw/wip) — this is the final state
     try {
-      await setGtwLabel(prNum, token, repo, 'gtw/revise', true);
+      await setPrLabel({ prNum, repo, token, isPR: true }, 'gtw/revise');
     } catch (e) {
       return { ok: false, message: `⚠️ ${e.message}` };
     }

--- a/utils/labels.js
+++ b/utils/labels.js
@@ -1,0 +1,107 @@
+/**
+ * Label system for gtw: 5 mutually exclusive labels.
+ *
+ * Exports:
+ *   GTW_LABELS          — array of the 5 label names
+ *   setPrLabel(ctx, label, api) — atomic set with mutual exclusion, concurrency rollback
+ *
+ * The api parameter defaults to the real apiRequest but can be overridden for tests.
+ */
+
+import { apiRequest as _defaultApiRequest } from './api.js';
+
+export const GTW_LABELS = ['gtw/ready', 'gtw/wip', 'gtw/lgtm', 'gtw/revise', 'gtw/stuck'];
+
+/**
+ * Context shape:
+ *   { prNum, repo, token, isPR? }
+ *
+ * api: optional injectable apiRequest(mock) for testing.
+ *
+ * Returns { ok, preempted, label } on success.
+ * Throws on network / API error (unless preemption rollback succeeds).
+ *
+ * Concurrency behavior for gtw/wip claim:
+ *   1. Atomically remove other gtw/* labels and set gtw/wip.
+ *   2. Re-fetch labels and check: if gtw/ready is still present, another
+ *      runner beat us → rollback gtw/wip → set gtw/ready → return { preempted: true }.
+ *   3. If rollback itself fails, throw (state is ambiguous).
+ */
+export async function setPrLabel(ctx, label, api = _defaultApiRequest) {
+  const { prNum, repo, token, isPR = true } = ctx;
+
+  if (!GTW_LABELS.includes(label)) {
+    throw new Error(
+      `Invalid gtw label: ${label}. Must be one of: ${GTW_LABELS.join(', ')}`,
+    );
+  }
+
+  const endpointBase = isPR
+    ? `/repos/${repo}/pulls/${prNum}`
+    : `/repos/${repo}/issues/${prNum}`;
+
+  // Step 1: fetch current labels
+  const currentLabels = await api('GET', `${endpointBase}/labels`, token);
+
+  // Step 2: remove other gtw/* labels
+  const toRemove = currentLabels
+    .map((l) => l.name)
+    .filter((name) => GTW_LABELS.includes(name) && name !== label);
+
+  for (const lbl of toRemove) {
+    try {
+      await api('DELETE', `${endpointBase}/labels/${encodeURIComponent(lbl)}`, token);
+    } catch (e) {
+      // 404 = label already gone (race), which is fine.
+      // Any other error: abort without continuing.
+      if (!e.message.includes('404') && !e.message.includes('Label not found')) {
+        throw new Error(
+          `Failed to remove label "${lbl}" from #${prNum}: ${e.message}. Aborting.`,
+        );
+      }
+    }
+  }
+
+  // Step 3: set target label (skip if already present)
+  const alreadyHas = currentLabels.some((l) => l.name === label);
+  if (!alreadyHas) {
+    try {
+      await api('POST', `${endpointBase}/labels`, token, { labels: [label] });
+    } catch (e) {
+      throw new Error(`Failed to set label "${label}" on #${prNum}: ${e.message}. Aborting.`);
+    }
+  }
+
+  // Step 4: concurrency safety — only needed when claiming gtw/wip
+  if (label === 'gtw/wip') {
+    const fresh = await api('GET', `${endpointBase}/labels`, token);
+    const wasPreempted = fresh.some((l) => l.name === 'gtw/ready');
+
+    if (wasPreempted) {
+      // Rollback: remove gtw/wip, restore gtw/ready
+      try {
+        await api(
+          'DELETE',
+          `${endpointBase}/labels/${encodeURIComponent('gtw/wip')}`,
+          token,
+        );
+      } catch (e) {
+        if (!e.message.includes('404') && !e.message.includes('Label not found')) {
+          throw new Error(
+            `Rollback failed: could not remove gtw/wip after preemption detected. State ambiguous: ${e.message}`,
+          );
+        }
+      }
+      try {
+        await api('POST', `${endpointBase}/labels`, token, { labels: ['gtw/ready'] });
+      } catch (e) {
+        throw new Error(
+          `Rollback failed: could not restore gtw/ready after preemption. State ambiguous: ${e.message}`,
+        );
+      }
+      return { ok: true, preempted: true, label };
+    }
+  }
+
+  return { ok: true, preempted: false, label };
+}

--- a/utils/labels.test.js
+++ b/utils/labels.test.js
@@ -1,0 +1,465 @@
+/**
+ * Unit tests for utils/labels.js — setPrLabel atomicity, rollback, and concurrency.
+ * Run: node --test utils/labels.test.js
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { GTW_LABELS, setPrLabel } from './labels.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a stateful mock API whose behavior changes based on call count.
+ * @param {Array<function>} handlers - array of handler functions, one per call
+ */
+function makeMockApi(handlers) {
+  let callIdx = 0;
+  return async function mockApi(method, path, token, body) {
+    if (callIdx >= handlers.length) {
+      throw new Error(`No handler for call #${callIdx} (${method} ${path}). Total handlers: ${handlers.length}`);
+    }
+    return handlers[callIdx++](method, path, token, body);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// GTW_LABELS
+// ---------------------------------------------------------------------------
+
+describe('GTW_LABELS', () => {
+  it('has exactly 5 mutually exclusive labels', () => {
+    assert.strictEqual(GTW_LABELS.length, 5);
+    assert.deepStrictEqual(
+      GTW_LABELS,
+      ['gtw/ready', 'gtw/wip', 'gtw/lgtm', 'gtw/revise', 'gtw/stuck'],
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC1: setPrLabel — label operation success
+// ---------------------------------------------------------------------------
+
+describe('setPrLabel: success (AC1 — mutual exclusion)', () => {
+  for (const label of GTW_LABELS) {
+    it(`sets ${label} and removes other gtw labels`, async () => {
+      // State: PR starts with gtw/ready + random-label. After DELETE(gtw/ready),
+      // POST(label) sets the target. For gtw/wip, a recheck GET is also made.
+      const operations = [];
+      let idx = 0;
+
+      // Correct call counts:
+      // gtw/ready: already present → only GET (no DELETE, no POST)
+      // gtw/lgtm/revise/stuck: DELETE gtw/ready + POST new → 3 calls (GET, DELETE, POST)
+      // gtw/wip: DELETE gtw/ready + POST + recheck GET → 4 calls
+      const isReady = label === 'gtw/ready';
+      const isWip = label === 'gtw/wip';
+
+      const handlers = [
+        async () => {
+          operations.push(`GET #${++idx}`);
+          return [{ name: 'gtw/ready' }, { name: 'random-label' }];
+        },
+        // DELETE gtw/ready (always removed — it's the only other gtw label present)
+        ...(isReady ? [] : [
+          async () => { operations.push(`DELETE #${++idx}`); return {}; },
+        ]),
+        // POST new label (skipped if gtw/ready already set)
+        ...(isReady ? [] : [
+          async () => { operations.push(`POST #${++idx}`); return {}; },
+        ]),
+        // GET recheck for gtw/wip claim
+        ...(isWip ? [
+          async () => {
+            operations.push(`GET-recheck #${++idx}`);
+            return [{ name: label }]; // gtw/ready removed, gtw/wip added
+          },
+        ] : []),
+      ];
+
+      const totalCalls = handlers.length;
+
+      const result = await setPrLabel(
+        { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+        label,
+        makeMockApi(handlers),
+      );
+
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(result.preempted, false);
+      assert.strictEqual(result.label, label);
+      assert.strictEqual(
+        operations.length,
+        totalCalls,
+        `Expected ${totalCalls} calls, got: ${operations.join(' → ')}`,
+      );
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// AC2: atomicity — network error aborts without state pollution
+// ---------------------------------------------------------------------------
+
+describe('setPrLabel: atomicity — network error aborts (AC2)', () => {
+  it('throws if removing a label fails with non-404 error', async () => {
+    const handlers = [
+      async () => [{ name: 'gtw/ready' }],
+      async () => {
+        throw new Error('GitHub API 500: Internal Server Error');
+      },
+    ];
+
+    await assert.rejects(
+      async () =>
+        setPrLabel(
+          { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+          'gtw/wip',
+          makeMockApi(handlers),
+        ),
+      /Failed to remove label "gtw\/ready".+Aborting/,
+    );
+  });
+
+  it('throws if setting the target label fails', async () => {
+    let postAttempted = false;
+    const handlers = [
+      async () => [{ name: 'gtw/ready' }],
+      async () => { /* DELETE succeeds */ return {}; },
+      async () => {
+        postAttempted = true;
+        throw new Error('GitHub API 403: Forbidden');
+      },
+    ];
+
+    await assert.rejects(
+      async () =>
+        setPrLabel(
+          { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+          'gtw/wip',
+          makeMockApi(handlers),
+        ),
+      /Failed to set label "gtw\/wip".+Aborting/,
+    );
+    assert.strictEqual(postAttempted, true);
+  });
+
+  it('aborts after DELETE+POST failure without further side-effects', async () => {
+    const ops = [];
+    const handlers = [
+      async () => {
+        ops.push('GET'); return [{ name: 'gtw/ready' }];
+      },
+      async () => {
+        ops.push('DELETE'); return {}; // removal succeeds
+      },
+      async () => {
+        ops.push('POST'); throw new Error('network error'); // POST fails
+      },
+    ];
+
+    await assert.rejects(
+      async () =>
+        setPrLabel(
+          { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+          'gtw/wip',
+          makeMockApi(handlers),
+        ),
+      /Aborting/,
+    );
+
+    // GET → DELETE (ok) → POST (fails) — no further calls
+    assert.deepStrictEqual(ops, ['GET', 'DELETE', 'POST']);
+  });
+
+  it('throws if initial GET fails', async () => {
+    await assert.rejects(
+      async () =>
+        setPrLabel(
+          { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+          'gtw/lgtm',
+          makeMockApi([async () => { throw new Error('ENOTFOUND DNS lookup failed'); }]),
+        ),
+      /ENOTFOUND/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC3: concurrency safe — gtw/wip preemption triggers rollback
+// ---------------------------------------------------------------------------
+
+describe('setPrLabel: concurrency — gtw/wip preemption with rollback (AC3)', () => {
+  it('gtw/wip: if gtw/ready still present after claim, rolls back and returns preempted=true', async () => {
+    const ops = [];
+    const handlers = [
+      // GET #1: current labels
+      async () => {
+        ops.push('GET#1'); return [{ name: 'gtw/ready' }];
+      },
+      // DELETE gtw/ready
+      async () => { ops.push('DELETE-gtw/ready'); return {}; },
+      // POST gtw/wip
+      async () => { ops.push('POST-gtw/wip'); return {}; },
+      // GET #2 (recheck): gtw/ready STILL present → preempted
+      async () => {
+        ops.push('GET#2-recheck'); return [{ name: 'gtw/ready' }];
+      },
+      // Rollback: DELETE gtw/wip
+      async () => { ops.push('DELETE-gtw/wip-rollback'); return {}; },
+      // Rollback: POST gtw/ready
+      async () => { ops.push('POST-gtw/ready-restore'); return {}; },
+    ];
+
+    const result = await setPrLabel(
+      { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+      'gtw/wip',
+      makeMockApi(handlers),
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.preempted, true);
+    assert.strictEqual(result.label, 'gtw/wip');
+    assert.deepStrictEqual(ops, [
+      'GET#1',
+      'DELETE-gtw/ready',
+      'POST-gtw/wip',
+      'GET#2-recheck',
+      'DELETE-gtw/wip-rollback',
+      'POST-gtw/ready-restore',
+    ]);
+  });
+
+  it('gtw/wip: if gtw/ready is gone after claim, no rollback, returns preempted=false', async () => {
+    const ops = [];
+    const handlers = [
+      async () => { ops.push('GET#1'); return [{ name: 'gtw/ready' }]; },
+      async () => { ops.push('DELETE-gtw/ready'); return {}; },
+      async () => { ops.push('POST-gtw/wip'); return {}; },
+      // Recheck: gtw/ready is GONE → claim succeeded cleanly
+      async () => { ops.push('GET#2-recheck'); return [{ name: 'gtw/wip' }]; },
+    ];
+
+    const result = await setPrLabel(
+      { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+      'gtw/wip',
+      makeMockApi(handlers),
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.preempted, false);
+    assert.strictEqual(result.label, 'gtw/wip');
+    // No rollback DELETE/POST for gtw/wip
+    assert.ok(!ops.some((op) => op.includes('rollback')), 'Should not rollback');
+  });
+
+  it('non-gtw/wip labels skip the concurrency re-check entirely', async () => {
+    for (const label of ['gtw/ready', 'gtw/lgtm', 'gtw/revise', 'gtw/stuck']) {
+      const ops = [];
+      const handlers = [
+        async () => { ops.push('GET'); return [{ name: 'gtw/wip' }]; }, // different label present
+        async () => { ops.push('DELETE-gtw/wip'); return {}; },
+        async () => { ops.push('POST'); return {}; },
+      ];
+
+      const result = await setPrLabel(
+        { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+        label,
+        makeMockApi(handlers),
+      );
+
+      assert.strictEqual(result.ok, true, `${label}: should succeed`);
+      assert.strictEqual(result.preempted, false, `${label}: should not preempt`);
+      // Only GET + DELETE + POST — no recheck GET
+      assert.strictEqual(ops.filter((op) => op === 'GET').length, 1, `${label}: exactly 1 GET`);
+    }
+  });
+
+  it('rollback DELETE 404 is tolerated (label already gone in race)', async () => {
+    const handlers = [
+      async () => [{ name: 'gtw/ready' }],
+      async () => { /* DELETE gtw/ready ok */ return {}; },
+      async () => { /* POST gtw/wip ok */ return {}; },
+      async () => [{ name: 'gtw/ready' }], // recheck: still there
+      async () => { throw new Error('404 Label not found'); }, // rollback DELETE gtw/wip → 404, tolerated
+      async () => { /* POST gtw/ready restore ok */ return {}; },
+    ];
+
+    const result = await setPrLabel(
+      { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+      'gtw/wip',
+      makeMockApi(handlers),
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.preempted, true);
+  });
+
+  it('throws if rollback POST fails (state ambiguous — must not silently continue)', async () => {
+    let rollbackDeleteDone = false;
+    const handlers = [
+      async () => [{ name: 'gtw/ready' }],
+      async () => { /* DELETE gtw/ready ok */ return {}; },
+      async () => { /* POST gtw/wip ok */ return {}; },
+      async () => [{ name: 'gtw/ready' }], // recheck: preempted
+      async () => { rollbackDeleteDone = true; return {}; }, // rollback DELETE gtw/wip
+      async () => { throw new Error('GitHub API 500: Rollback failed'); }, // rollback POST gtw/ready FAILS
+    ];
+
+    await assert.rejects(
+      async () =>
+        setPrLabel(
+          { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+          'gtw/wip',
+          makeMockApi(handlers),
+        ),
+      /Rollback failed.*State ambiguous/,
+    );
+    assert.strictEqual(rollbackDeleteDone, true);
+  });
+
+  it('throws if rollback DELETE fails with non-404 error (state ambiguous)', async () => {
+    const handlers = [
+      async () => [{ name: 'gtw/ready' }],
+      async () => { /* DELETE gtw/ready ok */ return {}; },
+      async () => { /* POST gtw/wip ok */ return {}; },
+      async () => [{ name: 'gtw/ready' }], // recheck: preempted
+      async () => { throw new Error('GitHub API 500: Internal Server Error'); }, // rollback DELETE fails
+    ];
+
+    await assert.rejects(
+      async () =>
+        setPrLabel(
+          { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+          'gtw/wip',
+          makeMockApi(handlers),
+        ),
+      /Rollback failed.*State ambiguous/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Invalid label
+// ---------------------------------------------------------------------------
+
+describe('setPrLabel: invalid label rejects cleanly', () => {
+  it('throws for a non-gtw label string', async () => {
+    await assert.rejects(
+      async () =>
+        setPrLabel(
+          { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+          'random-label',
+          async () => {},
+        ),
+      /Invalid gtw label: random-label/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 404 during label removal is non-fatal (already gone)
+// ---------------------------------------------------------------------------
+
+describe('setPrLabel: 404 during removal is non-fatal', () => {
+  it('404 on DELETE is tolerated (race: label already removed by another process)', async () => {
+    const ops = [];
+    const handlers = [
+      async () => { ops.push('GET'); return [{ name: 'gtw/ready' }]; },
+      async () => { ops.push('DELETE-404'); throw new Error('404 Label not found'); },
+      async () => { ops.push('POST'); return {}; },
+      // recheck GET for gtw/wip claim: gtw/ready gone, gtw/wip added
+      async () => { ops.push('GET-recheck'); return [{ name: 'gtw/wip' }]; },
+    ];
+
+    const result = await setPrLabel(
+      { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+      'gtw/wip',
+      makeMockApi(handlers),
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.preempted, false);
+    assert.strictEqual(result.label, 'gtw/wip');
+    // Should have continued to POST after the 404 DELETE
+    assert.deepStrictEqual(ops, ['GET', 'DELETE-404', 'POST', 'GET-recheck']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Target label already present: no-op on POST
+// ---------------------------------------------------------------------------
+
+describe('setPrLabel: target label already present — skips POST', () => {
+  it('if label already set (gtw/wip), skips POST and does recheck', async () => {
+    const ops = [];
+    const handlers = [
+      async () => { ops.push('GET'); return [{ name: 'gtw/wip' }]; }, // already has gtw/wip
+      // No DELETE needed (gtw/wip === target)
+      // No POST (alreadyHas = true)
+      async () => { ops.push('GET-recheck'); return [{ name: 'gtw/wip' }]; }, // recheck
+    ];
+
+    const result = await setPrLabel(
+      { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+      'gtw/wip',
+      makeMockApi(handlers),
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.preempted, false);
+    assert.deepStrictEqual(ops, ['GET', 'GET-recheck']);
+  });
+
+  it('if label already set (non-wip), skips POST and no recheck', async () => {
+    const ops = [];
+    const handlers = [
+      async () => { ops.push('GET'); return [{ name: 'gtw/lgtm' }]; },
+      // No DELETE (gtw/lgtm === target, excluded from toRemove)
+      // No POST (alreadyHas = true)
+    ];
+
+    const result = await setPrLabel(
+      { prNum: 1, repo: 'owner/repo', token: 'tok', isPR: true },
+      'gtw/lgtm',
+      makeMockApi(handlers),
+    );
+
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.preempted, false);
+    assert.deepStrictEqual(ops, ['GET']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isPR = false (issues, not PRs)
+// ---------------------------------------------------------------------------
+
+describe('setPrLabel: isPR=false uses issues endpoint', () => {
+  it('uses /issues/ not /pulls/ when isPR=false', async () => {
+    let capturedPath;
+
+    await setPrLabel(
+      { prNum: 42, repo: 'owner/repo', token: 'tok', isPR: false },
+      'gtw/ready',
+      async (method, path) => {
+        capturedPath = path;
+        if (method === 'GET') return [{ name: 'gtw/wip' }]; // not gtw/ready
+        if (method === 'POST') return {};
+        if (method === 'DELETE') return {};
+        throw new Error(`Unexpected: ${method}`);
+      },
+    );
+
+    assert.ok(
+      capturedPath.includes('/issues/42/labels'),
+      `Expected /issues/ path, got: ${capturedPath}`,
+    );
+    assert.ok(
+      !capturedPath.includes('/pulls/'),
+      `Should not use /pulls/ for issues, got: ${capturedPath}`,
+    );
+  });
+});


### PR DESCRIPTION
Implements atomic set/clear for 5 mutually exclusive gtw labels (ready/wip/lgtm/revise/stuck).

## Changes
- **utils/labels.js**: new  — mutual exclusion clears + atomic set + concurrency rollback
- **commands/ReviewCommand.js**: refactored to use  (net -63 lines)
- **utils/labels.test.js**: 21 tests covering success, network failure, and concurrent preemption

Closes #33