### PR TITLE
Add OpenClaw manifest fields to package.json (fix #51)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "GitHub team workflow - slash command plugin for OpenClaw",
   "type": "module",
   "main": "index.js",
+  "openclaw": {
+    "extensions": ["./index.js"],
+    "hooks": []
+  },
   "scripts": {
     "test": "node --test test/*.test.js",
     "test:watch": "node --test --watch test/*.test.js"


### PR DESCRIPTION
What changed:
- Added an "openclaw" object to package.json with:
  - "extensions": ["./index.js"]
  - "hooks": []
- This is strictly a metadata change; index.js remains the package "main" and no runtime code was modified.

Why it changed:
- OpenClaw 2026.4.x requires plugin metadata in package.json when installing local plugins. Recent commits removed these fields, causing installer failures such as missing openclaw.extensions and missing openclaw.hooks (which the installer expects during a hook-pack fallback).

How to test:
1) Verify package.json contains the new entries: "openclaw": { "extensions": ["./index.js"], "hooks": [] }.
2) Confirm OpenClaw version: run `openclaw --version` and ensure it reports 2026.4.x (e.g. 2026.4.1).
3) Install the plugin locally: `openclaw plugins install <path-to-gtw>` and verify the install completes without errors about missing openclaw.extensions or openclaw.hooks.
4) Verify runtime behavior: start the host/plugin as usual; the plugin should behave the same and continue to use index.js as its entry point.

Fixes: #51