### PR TITLE
Unclaim gtw/wip label on local git failures during fix

### DIFF
--- a/commands/FixCommand.js
+++ b/commands/FixCommand.js
@@ -211,10 +211,12 @@ export class FixCommand extends Commander {
     const workdir = wip.workdir;
     const repo = wip.repo;
 
+    // Get token once and reuse throughout the command
+    const token = await getValidToken();
+
     // Step 3: Fetch issue from GitHub
     let issue;
     try {
-      const token = await getValidToken();
       issue = await fetchIssue(issueId, token, repo);
     } catch (e) {
       if (e.message.includes('404')) {
@@ -231,7 +233,6 @@ export class FixCommand extends Commander {
 
     // Step 4: Claim the issue (add gtw/wip label) before any work
     try {
-      const token = await getValidToken();
       const claimResult = await claimIssue(issueId, token, repo);
       if (!claimResult.ok) {
         return {
@@ -262,6 +263,13 @@ export class FixCommand extends Commander {
       branchName = ensureUniqueBranch(workdir, baseBranchName);
       git(`git checkout -b ${branchName}`, workdir);
     } catch (e) {
+      // Best-effort attempt to remove the gtw/wip label before returning the failure.
+      // Errors from unclaimIssue() are logged but do not mask the original git error.
+      try {
+        await unclaimIssue(issueId, token, repo);
+      } catch (unclaimErr) {
+        console.error('[FixCommand] Warning: unclaimIssue() failed during git error recovery', unclaimErr);
+      }
       return { ok: false, message: `⚠️ Git branch creation failed: ${e.message}` };
     }
 


### PR DESCRIPTION
Fixes: #57

What changed:
- FixCommand.execute() now ensures the GitHub issue is unclaimed if any local git operation in Step 6 (git fetch, checkout default branch, git pull --rebase, or git checkout -b) fails. unclaimIssue() is awaited and any errors from that cleanup call are logged but do not mask the original git error. No other state files (wip.json, wip/latestFixStatus) or directive/subagent behavior are modified.

Why it changed:
- Previously, FixCommand would call claimIssue() early, then perform local git steps. If a local git step failed, the command returned without calling unclaimIssue(), leaving the issue labeled gtw/wip and blocking others from claiming it. This change ensures the label is removed on early local failures and preserves the original failure for diagnostics.

How to test (manual QA plan):
1. Reproduce a local git failure during Step 6 by one of these methods:
   - Temporarily rename or remove the remote so git fetch fails, or
   - Run in a network-disabled environment so git fetch/pull fails, or
   - Force git checkout -b to fail by creating a conflicting ref.
2. Run: gtw fix <issue-number> (the issue should be claimed with gtw/wip early in the flow).
3. Observe that the command exits with the original git error.
4. Verify on GitHub that the issue no longer has the gtw/wip label after the command returns.
5. Optional: Simulate unclaimIssue() throwing (mock/log) and confirm the original git error is still returned and that the unclaim attempt was made and logged.

Notes:
- This change only affects failures that occur before directive/subagent execution (local git steps). Subagent-level failures after directive issuance remain unchanged.
- Existing happy-path behavior is preserved: when local git steps succeed, the gtw/wip label remains as normal.

## Summary by Sourcery

Bug Fixes:
- Unclaim the gtw/wip label on the GitHub issue when local git operations for branch creation fail, while preserving the original git error returned to the user.