### PR TITLE
feat: save sessionKey to wip.json on /gtw on

### DIFF
--- a/commands/OnCommand.js
+++ b/commands/OnCommand.js
@@ -29,7 +29,7 @@ export class OnCommand extends Commander {
     if (!existsSync(absWorkdir)) throw new Error(`Directory not found: ${absWorkdir}`);
 
     const repo = getRemoteRepo(absWorkdir);
-    saveWip({ workdir: absWorkdir, repo, createdAt: new Date().toISOString() });
+    saveWip({ workdir: absWorkdir, repo, sessionKey: this.sessionKey, createdAt: new Date().toISOString() });
 
     // Inject PLAN MODE directive so the agent knows to discuss before coding
     const injected = injectPlanModeDirective(this.sessionKey, absWorkdir, repo);

--- a/commands/PrCommand.js
+++ b/commands/PrCommand.js
@@ -160,14 +160,14 @@ export class PrCommand extends Commander {
       derivedBranchName = `fix/${baseBranchName}`;
 
       // Robust checkout: handle remote-exists, local-only, not-found cases
-      checkoutStatus = tryCheckoutRemoteBranch(workdir, derivedBranchName);
+      checkoutStatus = await tryCheckoutRemoteBranch(workdir, derivedBranchName);
       headBranch = checkoutStatus.branch;
     }
     // -------------------------------------------------------------------
     // Mode: /gtw pr (no args) — always use current branch, never wip.json
     // -------------------------------------------------------------------
     else {
-      headBranch = getCurrentBranch(workdir);
+      headBranch = await getCurrentBranch(workdir);
       if (!headBranch) {
         throw new Error('Not on any branch. Use /gtw fix <issue_id> to create a branch first.');
       }

--- a/commands/PushCommand.js
+++ b/commands/PushCommand.js
@@ -89,7 +89,7 @@ export class PushCommand extends Commander {
     if (!wip.workdir) throw new Error('No workdir set. Run /gtw on <workdir> first');
 
     const workdir = wip.workdir;
-    const branch = getCurrentBranch(workdir);
+    const branch = await getCurrentBranch(workdir);
 
     await addAll(workdir);
 

--- a/utils/git.js
+++ b/utils/git.js
@@ -27,6 +27,11 @@ function findGitRoot(workdir) {
  * Execute a git command and return stdout.
  * Throws on non-zero exit.
  */
+// git — alias for execGit, used by ConfirmCommand and other legacy callers
+export function git(cmd, cwd) {
+  return execGit(cmd, cwd);
+}
+
 function execGit(cmd, cwd) {
   try {
     return _exec(cmd, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();


### PR DESCRIPTION
Squash merge of feat/save-session-key-to-wip

包含:
- save sessionKey to wip.json on /gtw on
- fix: await async calls in PrCommand
- fix: await getCurrentBranch in PushCommand  
- fix: re-export execGit as git for ConfirmCommand