### PR TITLE
fix: replace git pull --rebase with git reset --hard in gtw checkout and fix

### DIFF
--- a/commands/CheckoutCommand.js
+++ b/commands/CheckoutCommand.js
@@ -40,14 +40,14 @@ export class CheckoutCommand extends Commander {
       return { ok: false, message: `⚠️ Fetch failed:\n${e.message}` };
     }
 
-    // Step 2 & 3: checkout -B (create or reset) tracking branch + pull
+    // Step 2: checkout -B (create or reset) tracking branch to origin/<branch>
+    // No pull needed — checkout -B origin/<branch> already points us at origin/<branch>
     try {
       // -B: create branch if missing, or reset existing to origin/<branch>
       const checkoutResult = git(`git checkout -B ${branch} origin/${branch}`, workdir);
-      const pullResult = git(`git pull`, workdir);
 
       const finalBranch = await getCurrentBranch(workdir);
-      const output = [checkoutResult, pullResult].filter(Boolean).join('\n');
+      const output = [checkoutResult].filter(Boolean).join('\n');
       return {
         ok: true,
         branch: finalBranch,
@@ -89,12 +89,12 @@ export class CheckoutCommand extends Commander {
       return { ok: false, message: `⚠️ Fetch failed:\n${e.message}` };
     }
 
-    // Step 2 & 3: checkout -B current origin/current + pull
+    // Step 2: checkout -B current origin/current
+    // No pull needed — checkout -B origin/<branch> already points us at origin/<branch>
     try {
       const checkoutResult = git(`git checkout -B ${currentBranch} origin/${currentBranch}`, workdir);
-      const pullResult = git(`git pull`, workdir);
 
-      const output = [checkoutResult, pullResult].filter(Boolean).join('\n');
+      const output = [checkoutResult].filter(Boolean).join('\n');
       return {
         ok: true,
         branch: currentBranch,

--- a/commands/FixCommand.js
+++ b/commands/FixCommand.js
@@ -254,7 +254,7 @@ export class FixCommand extends Commander {
       await fetch(workdir, { remote: 'origin' });
       const defaultBranch = getDefaultBranch(workdir);
       await checkout(workdir, defaultBranch);
-      git(`git pull --rebase origin ${defaultBranch}`, workdir);
+      git(`git reset --hard origin/${defaultBranch}`, workdir);
       branchName = ensureUniqueBranch(workdir, baseBranchName);
       await checkout(workdir, branchName, { force: true });
     } catch (e) {


### PR DESCRIPTION
## Summary

- **gtw checkout**: Remove redundant `git pull` after `checkout -B origin/<branch>` since checkout already points to the correct origin commit
- **gtw fix**: Replace `git pull --rebase` with `git reset --hard origin/<defaultBranch>` to avoid unnecessary merge conflicts

Both commands still fetch latest changes from origin before updating.

Closes #95

## Summary by Sourcery

Simplify git branch synchronization in checkout and fix commands to avoid redundant pulls and reduce merge conflicts.

Bug Fixes:
- Prevent unnecessary merge conflicts in the fix workflow by hard-resetting the default branch to origin before creating a fix branch.

Enhancements:
- Remove redundant git pull after resetting local branches to their corresponding origin branches in the checkout workflow.