### PR TITLE
fix: increase subagent timeout from 600s to 1800s in FixCommand

### DIFF
--- a/commands/FixCommand.js
+++ b/commands/FixCommand.js
@@ -90,7 +90,7 @@ function injectFixDirective(sessionKey, sessionFile, issueId, workdir, branchNam
     ``,
     `Please perform the following steps in order:`,
     ``,
-    `1. Spawn a coding subagent (mode=run) in the workdir "${workdir}" with the following task:`,
+    `1. Spawn a coding subagent (mode=run, runTimeoutSeconds=1800) in the workdir "${workdir}" with the following task:`,
     ``,
     `   Task:`,
     `   ===`,


### PR DESCRIPTION
Fixes: #104

## What changed

Updated the spawn directive in `commands/FixCommand.js` to include `runTimeoutSeconds=1800` instead of relying on the default 600s timeout.

## Why it changed

The default 600-second timeout is insufficient for longer fix tasks. When running the `/fix` command, users encountered timeout issues for complex operations that required more execution time.

## How to test

1. Verify `FixCommand.js` contains `runTimeoutSeconds=1800` in the spawn directive (around line 86-136)
2. Run the `/fix` command with a task that takes longer than 600 seconds to confirm it completes without timeout
3. Ensure the application compiles and runs without errors

## Acceptance Criteria

- [x] `FixCommand.js` contains `runTimeoutSeconds=1800` in the spawn directive
- [x] Change compiles/runs without errors
- [x] Subagent spawned via `/fix` command uses 1800 second timeout

## Summary by Sourcery

Enhancements:
- Adjust the FixCommand subagent spawn directive to use a 1800-second run timeout instead of the previous default timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended timeout duration for the fix command to allow longer processing time for complex code modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->