### PR TITLE
feat(gtw): add detectUnnecessaryCleanup step to PR review flow

### DIFF
--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -368,8 +368,9 @@ export class ReviewCommand extends Commander {
           const severityBadge = c.severity === 'critical' ? '🔴 critical' :
             c.severity === 'high' ? '🟠 high' :
             c.severity === 'medium' ? '🟡 medium' : '🟢 low';
-          const whyCleanup = (c.whyCleanup || '').replace(/\|/g, '\\|');
-          const suggestion = (c.suggestion || '').replace(/\|/g, '\\|');
+          const toCell = (v) => String(v || '').replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
+          const whyCleanup = toCell(c.whyCleanup);
+          const suggestion = toCell(c.suggestion);
           comment += `| ${c.file} | ${c.symbol}: ${whyCleanup} | ${severityBadge} | ${suggestion} |\n`;
         }
         comment += '\n';

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -126,7 +126,7 @@ export class ReviewCommand extends Commander {
           );
         } catch (e) {
           console.error(`[ReviewCommand] Duplicate detection failed: ${e.message}`);
-          return { items: [], newFunctions: [] };
+          return { error: e.message, items: [], newFunctions: [] };
         }
       })(),
       (async () => {
@@ -172,7 +172,7 @@ export class ReviewCommand extends Commander {
     );
 
     let finalLabel = 'gtw/lgtm';
-    if (criticalItems.length > 0 || criticalCleanups.length > 0) {
+    if (duplicateResults.error || criticalItems.length > 0 || criticalCleanups.length > 0) {
       finalLabel = 'gtw/revise';
     }
 
@@ -341,7 +341,7 @@ export class ReviewCommand extends Commander {
       comment += '✅ **No duplicates, similar functions, or patterns found.**\n\n';
     }
 
-// Step 2: Unnecessary Cleanup section
+    // Step 2: Unnecessary Cleanup section
     const cleanups = cleanupResults.cleanups || [];
     const skipped = cleanupResults.skipped || [];
     const llmCandidates = cleanupResults.llmCandidates || [];
@@ -368,7 +368,9 @@ export class ReviewCommand extends Commander {
           const severityBadge = c.severity === 'critical' ? '🔴 critical' :
             c.severity === 'high' ? '🟠 high' :
             c.severity === 'medium' ? '🟡 medium' : '🟢 low';
-          comment += `| ${c.file} | ${c.symbol}: ${c.whyCleanup} | ${severityBadge} | ${c.suggestion} |\n`;
+          const whyCleanup = (c.whyCleanup || '').replace(/\|/g, '\\|');
+          const suggestion = (c.suggestion || '').replace(/\|/g, '\\|');
+          comment += `| ${c.file} | ${c.symbol}: ${whyCleanup} | ${severityBadge} | ${suggestion} |\n`;
         }
         comment += '\n';
 
@@ -387,7 +389,7 @@ export class ReviewCommand extends Commander {
       }
     }
 
-    comment += '---\n*Code Reuse detection via SimHash + codebase index + fuzzy search + LLM semantic analysis*';
+        comment += '---\n*Reviewed by gtw*';
 
     return comment;
   }

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -1,10 +1,15 @@
 /**
  * /gtw review — PR Review Command
  *
- * Step 1 only: Duplicate Detection
+ * Step 1: Duplicate Detection (detectReuse)
  * - Checks if new functions in PR duplicate existing functionality
  * - Uses git-aware per-branch codebase index
  * - Specialized LLM call for duplicate verdict
+ *
+ * Step 2: Unnecessary Cleanup Detection (detectUnnecessaryCleanup)
+ * - Detects stylistic/improvement changes to intentionally non-standard code
+ * - Phase A: Ref-based triage using codebase-index refs[]
+ * - Phase B: LLM analysis of filtered candidates
  */
 
 import { Commander } from './Commander.js';
@@ -12,6 +17,7 @@ import { getWip, saveWip } from '../utils/wip.js';
 import { GitHubClient } from '../utils/github.js';
 import { setPrLabel } from '../utils/labels.js';
 import { detectReuse } from '../utils/review-reuse.js';
+import { detectUnnecessaryCleanup } from '../utils/review-cleanup.js';
 import { prepareReviewWorktree } from './ReviewWorktree.js';
 
 export class ReviewCommand extends Commander {
@@ -105,24 +111,51 @@ export class ReviewCommand extends Commander {
       };
     }
 
-    // Step 1: Duplicate Detection
-    let duplicateResults;
-    try {
-      duplicateResults = await detectReuse(
-        prNum,
-        prData.baseBranch,
-        worktreePath,
-        repo,
-        client,
-        this.sessionKey
-      );
-    } catch (e) {
-      console.error(`[ReviewCommand] Duplicate detection failed: ${e.message}`);
-      duplicateResults = { items: [], newFunctions: [] };
-    }
+    // Run Step 1 (detectReuse) and Step 2 (detectUnnecessaryCleanup) in parallel
+    // Step 1 and Step 2 are independent — no shared reasoning
+    const [duplicateResults, cleanupResults] = await Promise.all([
+      (async () => {
+        try {
+          return await detectReuse(
+            prNum,
+            prData.baseBranch,
+            worktreePath,
+            repo,
+            client,
+            this.sessionKey
+          );
+        } catch (e) {
+          console.error(`[ReviewCommand] Duplicate detection failed: ${e.message}`);
+          return { items: [], newFunctions: [] };
+        }
+      })(),
+      (async () => {
+        // Build linked issue description for cleanup detection context
+        let issueDescription = null;
+        if (prData.linkedIssues && prData.linkedIssues.length > 0) {
+          issueDescription = prData.linkedIssues
+            .map(i => `Issue #${i.number}: ${i.title}\n${i.body || ''}`)
+            .join('\n\n');
+        }
+        try {
+          return await detectUnnecessaryCleanup(
+            prNum,
+            prData.baseBranch,
+            worktreePath,
+            repo,
+            client,
+            this.sessionKey,
+            issueDescription
+          );
+        } catch (e) {
+          console.error(`[ReviewCommand] Cleanup detection failed: ${e.message}`);
+          return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0 };
+        }
+      })(),
+    ]);
 
-    // Post comment with results
-    const comment = this._buildComment(prNum, prData, duplicateResults);
+    // Post comment with results (both steps)
+    const comment = this._buildComment(prNum, prData, duplicateResults, cleanupResults);
     let commentId;
     try {
       commentId = await this._postComment(prNum, repo, client, comment);
@@ -130,13 +163,16 @@ export class ReviewCommand extends Commander {
       console.error(`[ReviewCommand] Failed to post comment: ${e.message}`);
     }
 
-    // Determine verdict
+    // Determine verdict — both Step 1 and Step 2 verdicts are independent
     const criticalItems = duplicateResults.items.filter(
       (i) => i.verdict === 'duplicate' && ['critical', 'high'].includes(i.severity)
     );
+    const criticalCleanups = (cleanupResults.cleanups || []).filter(
+      (c) => ['critical', 'high'].includes(c.severity)
+    );
 
     let finalLabel = 'gtw/lgtm';
-    if (criticalItems.length > 0) {
+    if (criticalItems.length > 0 || criticalCleanups.length > 0) {
       finalLabel = 'gtw/revise';
     }
 
@@ -153,6 +189,7 @@ export class ReviewCommand extends Commander {
       [thisPrKey]: {
         commentId,
         items: duplicateResults.items,
+        cleanups: cleanupResults.cleanups || [],
         previousLabel: finalLabel,
         round: 1,
       },
@@ -168,8 +205,9 @@ export class ReviewCommand extends Commander {
       ``,
       prData.pr.title,
       ``,
-      `Functions analyzed: ${duplicateResults.newFunctions.length}`,
+      `Functions analyzed: ${duplicateResults.newFunctions?.length || 0}`,
       `Duplicates found: ${criticalItems.length}`,
+      `Unnecessary cleanups: ${criticalCleanups.length}`,
     ];
 
     if (criticalItems.length > 0) {
@@ -180,17 +218,25 @@ export class ReviewCommand extends Commander {
       }
     }
 
+    if (criticalCleanups.length > 0) {
+      summary.push(``, `Unnecessary cleanups:`);
+      for (const cleanup of criticalCleanups) {
+        summary.push(`  - ${cleanup.symbol} in ${cleanup.file}: ${cleanup.whyCleanup}`);
+      }
+    }
+
     return {
       ok: true,
       claimed: true,
       verdict: finalLabel,
       items: duplicateResults.items,
+      cleanups: cleanupResults.cleanups || [],
       message: summary.join('\n'),
       display: summary.join('\n'),
     };
   }
 
-  _buildComment(prNum, prData, results) {
+  _buildComment(prNum, prData, results, cleanupResults = {}) {
     const items = results.items || [];
 
     // Categorize items by verdict and severity
@@ -293,6 +339,52 @@ export class ReviewCommand extends Commander {
 
     if (items.length === 0) {
       comment += '✅ **No duplicates, similar functions, or patterns found.**\n\n';
+    }
+
+// Step 2: Unnecessary Cleanup section
+    const cleanups = cleanupResults.cleanups || [];
+    const skipped = cleanupResults.skipped || [];
+    const llmCandidates = cleanupResults.llmCandidates || [];
+    const modifiedFiles = cleanupResults.modifiedFiles || 0;
+    const noLinkedIssue = cleanupResults.noLinkedIssue || false;
+
+    comment += '\n\n### 🧹 Unnecessary Cleanup Check\n\n';
+
+    if (noLinkedIssue) {
+      comment += '*Step 2 skipped: no linked issue found for context.*\n\n';
+    } else {
+      comment += '**Phase A — Ref Triage:**\n';
+      comment += `- Files analyzed: ${modifiedFiles}\n`;
+      comment += `- Sent to LLM: ${llmCandidates.length}\n`;
+      comment += `- Skipped (low risk): ${skipped.length}\n\n`;
+
+      const criticalCleanups = cleanups.filter((c) => ['critical', 'high'].includes(c.severity));
+
+      if (cleanups.length > 0) {
+        comment += '**Findings:**\n\n';
+        comment += '| File | Change | Severity | Suggestion |\n';
+        comment += '|------|--------|----------|------------|\n';
+        for (const c of cleanups) {
+          const severityBadge = c.severity === 'critical' ? '🔴 critical' :
+            c.severity === 'high' ? '🟠 high' :
+            c.severity === 'medium' ? '🟡 medium' : '🟢 low';
+          comment += `| ${c.file} | ${c.symbol}: ${c.whyCleanup} | ${severityBadge} | ${c.suggestion} |\n`;
+        }
+        comment += '\n';
+
+        if (criticalCleanups.length > 0) {
+          comment += '**🚨 Critical/High Cleanups:**\n\n';
+          for (const c of criticalCleanups) {
+            const severityEmoji = c.severity === 'critical' ? '🔴' : '🟠';
+            comment += `**${severityEmoji} \`${c.symbol}\`** in ${c.file}\n`;
+            comment += `> Before: ${c.before?.slice(0, 100) || '(empty)'}${c.before?.length > 100 ? '...' : ''}\n`;
+            comment += `> After: ${c.after?.slice(0, 100) || '(empty)'}${c.after?.length > 100 ? '...' : ''}\n`;
+            comment += `> Why problematic: ${c.whyProblematic}\n\n`;
+          }
+        }
+      } else {
+        comment += '✅ **No unnecessary cleanups detected.**\n\n';
+      }
     }
 
     comment += '---\n*Code Reuse detection via SimHash + codebase index + fuzzy search + LLM semantic analysis*';

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -149,7 +149,7 @@ export class ReviewCommand extends Commander {
           );
         } catch (e) {
           console.error(`[ReviewCommand] Cleanup detection failed: ${e.message}`);
-          return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0 };
+          return { error: e.message, cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0 };
         }
       })(),
     ]);
@@ -172,7 +172,7 @@ export class ReviewCommand extends Commander {
     );
 
     let finalLabel = 'gtw/lgtm';
-    if (duplicateResults.error || criticalItems.length > 0 || criticalCleanups.length > 0) {
+    if (duplicateResults.error || cleanupResults.error || criticalItems.length > 0 || criticalCleanups.length > 0) {
       finalLabel = 'gtw/revise';
     }
 

--- a/utils/review-cleanup.js
+++ b/utils/review-cleanup.js
@@ -10,7 +10,6 @@ import {
   checkIndexFreshness,
   getOrBuildIndex,
   loadIndex,
-  getRemoteBranchHead,
 } from './codebase-index.js';
 import { resolveModel, callAI } from './ai.js';
 
@@ -124,7 +123,7 @@ function getModifiedFiles(worktreePath, baseRef, headRef) {
 function extractChangedSymbols(diff, file) {
   const ext = file.split('.').pop().toLowerCase();
   const lang = EXT_TO_LANG[ext] || 'javascript';
-  const pattern = FUNC_PATTERNS[lang] || FUNC_PATTERNS.javascript;
+  const pattern = FUNC_PATTERNS[lang] || FUNC_PATTERNS['javascript'];
 
   const changes = [];
   const lines = diff.split('\n');
@@ -371,19 +370,13 @@ export async function detectUnnecessaryCleanup(prNum, baseBranch, worktreePath, 
     return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0, noLinkedIssue: false };
   }
 
-  const headRef = await getRemoteBranchHead(worktreePath, baseBranch).then(
-    () => client.request('GET', `/repos/${repo}/pulls/${prNum}`).then(r => r.head?.ref),
-    () => null
-  );
-
-  if (!headRef) {
-    try {
-      const prDetails = await client.request('GET', `/repos/${repo}/pulls/${prNum}`);
-      headRef = prDetails.head?.ref;
-    } catch (e) {
-      console.error(`[review-cleanup] Failed to get PR head ref: ${e.message}`);
-      return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0, noLinkedIssue: false };
-    }
+  let headRef;
+  try {
+    const prDetails = await client.request('GET', `/repos/${repo}/pulls/${prNum}`);
+    headRef = prDetails.head?.ref;
+  } catch (e) {
+    console.error(`[review-cleanup] Failed to get PR head ref: ${e.message}`);
+    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0, noLinkedIssue: false };
   }
 
   if (!headRef) {

--- a/utils/review-cleanup.js
+++ b/utils/review-cleanup.js
@@ -3,27 +3,22 @@
  *
  * Detects whether a PR makes stylistic/improvement changes to code that was
  * intentionally non-standard (historical reasons, performance, compatibility).
- * Runs in parallel with Step 1 (detectReuse).
  */
 
+import { exec } from './exec.js';
 import {
   checkIndexFreshness,
   getOrBuildIndex,
   loadIndex,
-  getChangedFiles,
+  getRemoteBranchHead,
 } from './codebase-index.js';
 import { resolveModel, callAI } from './ai.js';
-import { exec } from './exec.js';
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 const INTERNAL_RATIO_THRESHOLD = 0.8;
-
-/**
- * Changes below this confidence are not reported.
- */
 const CONFIDENCE_THRESHOLD = 0.80;
 
 // ---------------------------------------------------------------------------
@@ -73,7 +68,7 @@ Rules:
 - Output empty array if no cleanups found`;
 
 // ---------------------------------------------------------------------------
-// Symbol change detection from diff
+// Language and pattern definitions
 // ---------------------------------------------------------------------------
 
 const EXT_TO_LANG = {
@@ -87,52 +82,49 @@ const EXT_TO_LANG = {
 };
 
 const FUNC_PATTERNS = {
-  js: /^(?:export\s+)?(?:async\s+)?function\s+(\w+)|^(?:export\s+)?(?:async\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\(|^(?:export\s+)?class\s+(\w+)/,
-  ts: /^(?:export\s+)?(?:async\s+)?function\s+(\w+)|^(?:export\s+)?(?:async\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\(|^(?:export\s+)?class\s+(\w+)/,
-  py: /^def\s+(\w+)|^async\s+def\s+(\w+)|^class\s+(\w+)/,
+  javascript: /^(?:export\s+)?(?:async\s+)?function\s+(\w+)|^(?:export\s+)?(?:async\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\(|^(?:export\s+)?class\s+(\w+)/,
+  typescript: /^(?:export\s+)?(?:async\s+)?function\s+(\w+)|^(?:export\s+)?(?:async\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\(|^(?:export\s+)?class\s+(\w+)/,
+  python: /^def\s+(\w+)|^async\s+def\s+(\w+)|^class\s+(\w+)/,
   go: /^func\s+(\w+)|^func\s+\([\w\s]+\*?\w+\)\s+(\w+)/,
   rust: /^pub\s+(?:async\s+)?fn\s+(\w+)|^pub\s+struct\s+(\w+)|^pub\s+enum\s+(\w+)/,
 };
 
+// ---------------------------------------------------------------------------
+// Git helpers
+// ---------------------------------------------------------------------------
+
 /**
- * Get all modified files in a PR, excluding new files and deletions.
+ * Get only MODIFIED files in a PR (excludes new files and deletions).
  * @param {string} worktreePath
  * @param {string} baseRef
  * @param {string} headRef
- * @returns {string[]} - list of modified file paths
+ * @returns {string[]}
  */
 function getModifiedFiles(worktreePath, baseRef, headRef) {
-  const allChanged = getChangedFiles(worktreePath, `origin/${baseRef}`, `origin/${headRef}`);
-
-  // Get only modified files (not new, not deleted)
-  // We check if file exists in both base and head
-  const modified = [];
-  for (const file of allChanged) {
-    try {
-      // Check if file exists in base (wasn't added)
-      const baseExists = exec(
-        `git show origin/${baseRef}:${file} > /dev/null 2>&1 && echo yes || echo no`,
-        { cwd: worktreePath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
-      ).toString().trim();
-
-      if (baseExists === 'yes') {
-        modified.push(file);
-      }
-    } catch {
-      // If we can't check, skip the file
-    }
-  }
-  return modified;
+  const output = exec(
+    `git diff origin/${baseRef}..origin/${headRef} --name-only --diff-filter=M`,
+    { cwd: worktreePath, stdio: ['pipe', 'pipe', 'pipe'] }
+  );
+  return output.toString().split('\n').map(f => f.trim()).filter(Boolean);
 }
 
+// ---------------------------------------------------------------------------
+// Symbol extraction from diff
+// ---------------------------------------------------------------------------
+
 /**
- * Extract changed symbols from a diff for a single file.
- * Returns { before, after, signature, name, line } for each changed function.
+ * Extract changed functions from a unified diff.
+ * Returns [{ name, file, lang, before, after, line }].
+ * Tracks brace depth to know when a function body ends.
+ *
+ * @param {string} diff
+ * @param {string} file
+ * @returns {Array}
  */
 function extractChangedSymbols(diff, file) {
   const ext = file.split('.').pop().toLowerCase();
   const lang = EXT_TO_LANG[ext] || 'javascript';
-  const pattern = FUNC_PATTERNS[lang === 'typescript' ? 'ts' : lang] || FUNC_PATTERNS.js;
+  const pattern = FUNC_PATTERNS[lang] || FUNC_PATTERNS.javascript;
 
   const changes = [];
   const lines = diff.split('\n');
@@ -145,14 +137,10 @@ function extractChangedSymbols(diff, file) {
   let inFunc = false;
   let braceDepth = 0;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-
-    // Hunk header
+  for (const line of lines) {
     const hunkMatch = line.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
     if (hunkMatch) {
-      // Save previous function if any
-      if (currentFunc && (beforeLines.length > 0 || afterLines.length > 0)) {
+      if (currentFunc && braceDepth > 0) {
         changes.push({
           name: currentFunc,
           file,
@@ -175,22 +163,17 @@ function extractChangedSymbols(diff, file) {
     if (line.startsWith('-')) {
       baseLineNum++;
       const trimmed = line.slice(1);
-
-      // Check for function definition
       if (!inFunc) {
         const match = trimmed.match(pattern);
         if (match) {
           currentFunc = match[1] || match[2] || match[3];
           inFunc = true;
-          beforeLines.push(trimmed);
         }
-      } else {
-        beforeLines.push(trimmed);
       }
+      if (inFunc) beforeLines.push(trimmed);
     } else if (line.startsWith('+')) {
       headLineNum++;
       const trimmed = line.slice(1);
-
       if (!inFunc) {
         const match = trimmed.match(pattern);
         if (match) {
@@ -198,29 +181,16 @@ function extractChangedSymbols(diff, file) {
           inFunc = true;
         }
       }
-
-      if (inFunc) {
-        afterLines.push(trimmed);
-        // Track brace depth for function body
-        braceDepth += (trimmed.match(/{/g) || []).length - (trimmed.match(/}/g) || []).length;
-        // Function ends when brace depth goes negative (wasn't in body yet) or
-        // when we see a new function definition
-      }
+      if (inFunc) afterLines.push(trimmed);
     } else if (line.startsWith(' ')) {
       baseLineNum++;
       headLineNum++;
-
-      // Context line — if we're in a function, include it
+      const trimmed = line.slice(1);
       if (inFunc) {
-        const trimmed = line.slice(1);
         beforeLines.push(trimmed);
         afterLines.push(trimmed);
         braceDepth += (trimmed.match(/{/g) || []).length - (trimmed.match(/}/g) || []).length;
-      }
-
-      // End of function body
-      if (inFunc && braceDepth < 0) {
-        if (currentFunc && (beforeLines.length > 0 || afterLines.length > 0)) {
+        if (braceDepth <= 0) {
           changes.push({
             name: currentFunc,
             file,
@@ -229,17 +199,16 @@ function extractChangedSymbols(diff, file) {
             after: afterLines.join('\n'),
             line: headLineNum,
           });
+          currentFunc = null;
+          beforeLines = [];
+          afterLines = [];
+          inFunc = false;
+          braceDepth = 0;
         }
-        currentFunc = null;
-        beforeLines = [];
-        afterLines = [];
-        inFunc = false;
-        braceDepth = 0;
       }
     }
   }
 
-  // Don't forget last function
   if (currentFunc && (beforeLines.length > 0 || afterLines.length > 0)) {
     changes.push({
       name: currentFunc,
@@ -254,40 +223,15 @@ function extractChangedSymbols(diff, file) {
   return changes;
 }
 
-/**
- * Build symbol ID from file path and symbol name.
- * Matches the format used in codebase-index.js.
- */
-function buildSymbolId(file, name) {
-  return `${file}:${name}`;
-}
-
-/**
- * Find symbol in base index by name in a specific file.
- * Returns { symbol, symbolId } or null.
- */
-function findSymbolInIndex(fileIndex, file, name) {
-  const fileSymbols = fileIndex[file];
-  if (!fileSymbols) return null;
-
-  for (const sym of fileSymbols) {
-    if (sym.name === name) {
-      const symbolId = sym.symbolId || `${file}:${sym.kind || 'func'}:${name}`;
-      return { symbol: sym, symbolId };
-    }
-  }
-  return null;
-}
-
 // ---------------------------------------------------------------------------
 // Phase A: Ref-Based Triage
 // ---------------------------------------------------------------------------
 
 /**
- * Phase A triage using codebase-index refs[] data.
+ * Filter changed symbols based on reference data from the base index.
  *
- * @param {Array} changedSymbols - [{name, file, lang, before, after, line}]
- * @param {Object} baseIndexData - loaded index data with refs
+ * @param {Array} changedSymbols
+ * @param {Object} baseIndexData - { files, refs }
  * @returns {{ llmCandidates: Array, skipped: Array }}
  */
 function phaseATriage(changedSymbols, baseIndexData) {
@@ -296,42 +240,11 @@ function phaseATriage(changedSymbols, baseIndexData) {
   const skipped = [];
 
   for (const candidate of changedSymbols) {
-    const { name, file, before, after, lang } = candidate;
+    const { name, file } = candidate;
+    const symbolId = `${file}:func:${name}`;
 
-    // Build possible symbol IDs to look up
-    const possibleIds = [
-      `${file}:${name}`,
-      `${file}:func:${name}`,
-      `${file}:${lang}:${name}`,
-    ];
-
-    let symbolId = null;
-    let symbolData = null;
-
-    for (const sid of possibleIds) {
-      if (refs[sid]) {
-        symbolId = sid;
-        symbolData = { symbolId: sid };
-        break;
-      }
-    }
-
-    // Also try searching by name in the file's symbols
-    if (!symbolId) {
-      const found = findSymbolInIndex(fileIndex, file, name);
-      if (found) {
-        symbolId = found.symbolId;
-        symbolData = found;
-      }
-    }
-
-    if (!symbolId || !refs[symbolId]) {
-      // Cannot resolve to base index → send to LLM (conservative)
-      llmCandidates.push({
-        ...candidate,
-        symbolId: symbolId || `unresolved:${file}:${name}`,
-        triageReason: 'unresolvable',
-      });
+    if (!refs[symbolId]) {
+      llmCandidates.push({ ...candidate, symbolId, triageReason: 'unresolvable' });
       continue;
     }
 
@@ -339,29 +252,17 @@ function phaseATriage(changedSymbols, baseIndexData) {
     const totalRefs = symbolRefs.length;
 
     if (totalRefs === 0) {
-      // No external callers → low risk, SKIP
       skipped.push({ ...candidate, symbolId, triageReason: 'no-external-refs' });
       continue;
     }
 
-    // Count refs inside PR (we can't know exactly, so estimate based on file)
-    // For triage: if internalRatio > 0.8, skip
-    // We approximate internalRatio by counting refs to the same file
     const internalRefs = symbolRefs.filter(r => r.file === file).length;
-    const internalRatio = internalRefs / totalRefs;
+    const internalRatio = totalRefs > 0 ? internalRefs / totalRefs : 0;
 
     if (internalRatio > INTERNAL_RATIO_THRESHOLD) {
-      // Overwhelmingly self-contained → low risk, SKIP
       skipped.push({ ...candidate, symbolId, internalRatio, triageReason: 'low-external-impact' });
     } else {
-      // External callers exist → needs LLM check
-      llmCandidates.push({
-        ...candidate,
-        symbolId,
-        internalRatio,
-        totalRefs,
-        triageReason: 'external-callers',
-      });
+      llmCandidates.push({ ...candidate, symbolId, internalRatio, totalRefs, triageReason: 'external-callers' });
     }
   }
 
@@ -373,12 +274,16 @@ function phaseATriage(changedSymbols, baseIndexData) {
 // ---------------------------------------------------------------------------
 
 /**
- * Call LLM to detect unnecessary cleanups in filtered candidates.
+ * Send candidates to LLM for unnecessary cleanup analysis.
+ *
+ * @param {Array} llmCandidates
+ * @param {string} issueDescription
+ * @param {string} sessionKey
+ * @returns {Promise<Array>}
  */
 async function phaseBLLMAnalysis(llmCandidates, issueDescription, sessionKey) {
   if (llmCandidates.length === 0) return [];
 
-  // Build prompt with before/after snippets
   const changesText = llmCandidates
     .map(c => {
       let entry = `File: ${c.file}\nSymbol: ${c.name}\n`;
@@ -390,7 +295,6 @@ async function phaseBLLMAnalysis(llmCandidates, issueDescription, sessionKey) {
     .join('\n---\n\n');
 
   const systemPrompt = CLEANUP_SYSTEM_PROMPT.replace('{issue_description}', issueDescription || '(no linked issue)');
-
   const userPrompt = `Review these code changes for unnecessary cleanup:\n\n${changesText}\n\nOutput JSON with your findings.`;
 
   let lastError = null;
@@ -436,25 +340,23 @@ async function phaseBLLMAnalysis(llmCandidates, issueDescription, sessionKey) {
 /**
  * Main entry point: detect unnecessary cleanup in a PR.
  *
- * @param {number} prNum - PR number
- * @param {string} baseBranch - Target branch (e.g. 'main')
- * @param {string} worktreePath - Worktree path for git operations
+ * @param {number} prNum
+ * @param {string} baseBranch
+ * @param {string} worktreePath
  * @param {string} repo - "owner/repo"
- * @param {GitHubClient} client - GitHub API client
- * @param {string} sessionKey - Session key for LLM calls
- * @param {string|null} issueDescription - Linked issue description (for LLM context)
- * @returns {Promise<{ cleanups: Array, llmCandidates: Array, skipped: Array, modifiedFiles: number }>}
+ * @param {object} client - GitHub API client
+ * @param {string} sessionKey
+ * @param {string|null} issueDescription
+ * @returns {Promise<{ cleanups: Array, llmCandidates: Array, skipped: Array, modifiedFiles: number, noLinkedIssue: boolean }>}
  */
 export async function detectUnnecessaryCleanup(prNum, baseBranch, worktreePath, repo, client, sessionKey, issueDescription = null) {
   console.log(`[review-cleanup] Starting for PR #${prNum} (base: ${baseBranch})`);
 
-  // If no linked issue, skip (not a real PR for cleanup detection purposes)
   if (!issueDescription) {
     console.log(`[review-cleanup] No linked issue — skipping Step 2`);
     return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0, noLinkedIssue: true };
   }
 
-  // Ensure base branch index is fresh
   const freshness = checkIndexFreshness(repo, baseBranch, worktreePath);
   console.log(`[review-cleanup] Freshness: ${freshness.fresh} (indexed: ${freshness.indexedCommit?.slice(0, 7)}, current: ${freshness.currentCommit?.slice(0, 7)})`);
 
@@ -463,34 +365,37 @@ export async function detectUnnecessaryCleanup(prNum, baseBranch, worktreePath, 
     getOrBuildIndex(worktreePath, repo, baseBranch);
   }
 
-  // Load base branch index
   const baseIndexData = loadIndex(repo, baseBranch);
   if (!baseIndexData || !baseIndexData.files || Object.keys(baseIndexData.files).length === 0) {
     console.log(`[review-cleanup] No index found for ${repo}@${baseBranch}`);
-    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0 };
+    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0, noLinkedIssue: false };
   }
 
-  // Get PR head ref
-  let headRef;
-  try {
-    const prDetails = await client.request('GET', `/repos/${repo}/pulls/${prNum}`);
-    headRef = prDetails.head?.ref;
-  } catch (e) {
-    console.error(`[review-cleanup] Failed to get PR head ref: ${e.message}`);
-    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0 };
+  const headRef = await getRemoteBranchHead(worktreePath, baseBranch).then(
+    () => client.request('GET', `/repos/${repo}/pulls/${prNum}`).then(r => r.head?.ref),
+    () => null
+  );
+
+  if (!headRef) {
+    try {
+      const prDetails = await client.request('GET', `/repos/${repo}/pulls/${prNum}`);
+      headRef = prDetails.head?.ref;
+    } catch (e) {
+      console.error(`[review-cleanup] Failed to get PR head ref: ${e.message}`);
+      return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0, noLinkedIssue: false };
+    }
   }
 
   if (!headRef) {
     console.log(`[review-cleanup] No head ref for PR #${prNum}`);
-    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0 };
+    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0, noLinkedIssue: false };
   }
 
-  // Phase A: Get modified files and extract changed symbols
   const modifiedFiles = getModifiedFiles(worktreePath, baseBranch, headRef);
   console.log(`[review-cleanup] Modified files (excluding new): ${modifiedFiles.length}`);
 
   if (modifiedFiles.length === 0) {
-    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0 };
+    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0, noLinkedIssue: false };
   }
 
   const allChangedSymbols = [];
@@ -498,9 +403,9 @@ export async function detectUnnecessaryCleanup(prNum, baseBranch, worktreePath, 
     try {
       const diff = exec(
         `git diff origin/${baseBranch}..origin/${headRef} -- "${file}"`,
-        { cwd: worktreePath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+        { cwd: worktreePath, stdio: ['pipe', 'pipe', 'pipe'] }
       );
-      const symbols = extractChangedSymbols(diff, file);
+      const symbols = extractChangedSymbols(diff.toString(), file);
       allChangedSymbols.push(...symbols);
     } catch (e) {
       console.error(`[review-cleanup] Failed to diff ${file}: ${e.message}`);
@@ -510,14 +415,12 @@ export async function detectUnnecessaryCleanup(prNum, baseBranch, worktreePath, 
   console.log(`[review-cleanup] Changed symbols extracted: ${allChangedSymbols.length}`);
 
   if (allChangedSymbols.length === 0) {
-    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: modifiedFiles.length };
+    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: modifiedFiles.length, noLinkedIssue: false };
   }
 
-  // Phase A: Ref-based triage
   const { llmCandidates, skipped } = phaseATriage(allChangedSymbols, baseIndexData);
   console.log(`[review-cleanup] Phase A triage: ${llmCandidates.length} → LLM, ${skipped.length} skipped`);
 
-  // Phase B: LLM Analysis
   const cleanups = await phaseBLLMAnalysis(llmCandidates, issueDescription, sessionKey);
   console.log(`[review-cleanup] Phase B LLM found ${cleanups.length} cleanups`);
 
@@ -526,5 +429,6 @@ export async function detectUnnecessaryCleanup(prNum, baseBranch, worktreePath, 
     llmCandidates,
     skipped,
     modifiedFiles: modifiedFiles.length,
+    noLinkedIssue: false,
   };
 }

--- a/utils/review-cleanup.js
+++ b/utils/review-cleanup.js
@@ -64,7 +64,7 @@ Rules:
 - high = clearly unnecessary with potential hidden behavior change
 - medium = stylistic cleanup, low risk
 - low = minor cleanup, likely safe but still unnecessary
-- Output empty array if no cleanups found`;
+- Output an object with an empty cleanups array if no cleanups found`;
 
 // ---------------------------------------------------------------------------
 // Language and pattern definitions
@@ -139,7 +139,7 @@ function extractChangedSymbols(diff, file) {
   for (const line of lines) {
     const hunkMatch = line.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
     if (hunkMatch) {
-      if (currentFunc && braceDepth > 0) {
+      if (currentFunc && (braceDepth > 0 || beforeLines.length > 0 || afterLines.length > 0)) {
         changes.push({
           name: currentFunc,
           file,

--- a/utils/review-cleanup.js
+++ b/utils/review-cleanup.js
@@ -169,7 +169,10 @@ function extractChangedSymbols(diff, file) {
           inFunc = true;
         }
       }
-      if (inFunc) beforeLines.push(trimmed);
+      if (inFunc) {
+        beforeLines.push(trimmed);
+        braceDepth += (trimmed.match(/{/g) || []).length - (trimmed.match(/}/g) || []).length;
+      }
     } else if (line.startsWith('+')) {
       headLineNum++;
       const trimmed = line.slice(1);
@@ -180,7 +183,10 @@ function extractChangedSymbols(diff, file) {
           inFunc = true;
         }
       }
-      if (inFunc) afterLines.push(trimmed);
+      if (inFunc) {
+        afterLines.push(trimmed);
+        braceDepth += (trimmed.match(/{/g) || []).length - (trimmed.match(/}/g) || []).length;
+      }
     } else if (line.startsWith(' ')) {
       baseLineNum++;
       headLineNum++;
@@ -243,7 +249,7 @@ function phaseATriage(changedSymbols, baseIndexData) {
     const symbolId = `${file}:func:${name}`;
 
     if (!refs[symbolId]) {
-      llmCandidates.push({ ...candidate, symbolId, triageReason: 'unresolvable' });
+      skipped.push({ ...candidate, symbolId, triageReason: 'no-external-refs' });
       continue;
     }
 

--- a/utils/review-cleanup.js
+++ b/utils/review-cleanup.js
@@ -1,0 +1,530 @@
+/**
+ * Unnecessary Cleanup Detection — Review flow Step 2.
+ *
+ * Detects whether a PR makes stylistic/improvement changes to code that was
+ * intentionally non-standard (historical reasons, performance, compatibility).
+ * Runs in parallel with Step 1 (detectReuse).
+ */
+
+import {
+  checkIndexFreshness,
+  getOrBuildIndex,
+  loadIndex,
+  getChangedFiles,
+} from './codebase-index.js';
+import { resolveModel, callAI } from './ai.js';
+import { exec } from './exec.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const INTERNAL_RATIO_THRESHOLD = 0.8;
+
+/**
+ * Changes below this confidence are not reported.
+ */
+const CONFIDENCE_THRESHOLD = 0.80;
+
+// ---------------------------------------------------------------------------
+// System prompt for LLM
+// ---------------------------------------------------------------------------
+
+const CLEANUP_SYSTEM_PROMPT = `You are reviewing code changes against a GitHub issue.
+
+Issue describes the problem/feature:
+{issue_description}
+
+A change is "unnecessary cleanup" if:
+- The original code worked correctly (no bug)
+- The change makes code "more standard/modern/elegant"
+- The issue did not require this improvement
+
+Key signals of unnecessary cleanup:
+- "Unusual" pattern replaced with "standard" one
+- Manual implementation replaced with library call
+- Older style replaced with newer style
+- Longer form replaced with shorter form
+- The original code might have been intentional
+
+Output ONLY valid JSON:
+{
+  "cleanups": [
+    {
+      "file": "path",
+      "symbol": "function/class name",
+      "before": "original code snippet",
+      "after": "changed code snippet",
+      "whyCleanup": "why this appears to be stylistic improvement, not required by issue",
+      "whyProblematic": "what risk does this introduce",
+      "severity": "critical | high | medium | low",
+      "suggestion": "revert | review-required",
+      "confidence": 0.85
+    }
+  ]
+}
+
+Rules:
+- Only report confidence >= 0.80
+- critical = original was likely intentional with hidden constraints
+- high = clearly unnecessary with potential hidden behavior change
+- medium = stylistic cleanup, low risk
+- low = minor cleanup, likely safe but still unnecessary
+- Output empty array if no cleanups found`;
+
+// ---------------------------------------------------------------------------
+// Symbol change detection from diff
+// ---------------------------------------------------------------------------
+
+const EXT_TO_LANG = {
+  js: 'javascript', mjs: 'javascript', cjs: 'javascript',
+  ts: 'typescript', tsx: 'typescript', jsx: 'javascript',
+  py: 'python',
+  go: 'go',
+  rs: 'rust',
+  java: 'java', rb: 'ruby', cs: 'csharp',
+  cpp: 'cpp', c: 'c', h: 'c', hpp: 'cpp',
+};
+
+const FUNC_PATTERNS = {
+  js: /^(?:export\s+)?(?:async\s+)?function\s+(\w+)|^(?:export\s+)?(?:async\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\(|^(?:export\s+)?class\s+(\w+)/,
+  ts: /^(?:export\s+)?(?:async\s+)?function\s+(\w+)|^(?:export\s+)?(?:async\s+)?(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\(|^(?:export\s+)?class\s+(\w+)/,
+  py: /^def\s+(\w+)|^async\s+def\s+(\w+)|^class\s+(\w+)/,
+  go: /^func\s+(\w+)|^func\s+\([\w\s]+\*?\w+\)\s+(\w+)/,
+  rust: /^pub\s+(?:async\s+)?fn\s+(\w+)|^pub\s+struct\s+(\w+)|^pub\s+enum\s+(\w+)/,
+};
+
+/**
+ * Get all modified files in a PR, excluding new files and deletions.
+ * @param {string} worktreePath
+ * @param {string} baseRef
+ * @param {string} headRef
+ * @returns {string[]} - list of modified file paths
+ */
+function getModifiedFiles(worktreePath, baseRef, headRef) {
+  const allChanged = getChangedFiles(worktreePath, `origin/${baseRef}`, `origin/${headRef}`);
+
+  // Get only modified files (not new, not deleted)
+  // We check if file exists in both base and head
+  const modified = [];
+  for (const file of allChanged) {
+    try {
+      // Check if file exists in base (wasn't added)
+      const baseExists = exec(
+        `git show origin/${baseRef}:${file} > /dev/null 2>&1 && echo yes || echo no`,
+        { cwd: worktreePath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+      ).toString().trim();
+
+      if (baseExists === 'yes') {
+        modified.push(file);
+      }
+    } catch {
+      // If we can't check, skip the file
+    }
+  }
+  return modified;
+}
+
+/**
+ * Extract changed symbols from a diff for a single file.
+ * Returns { before, after, signature, name, line } for each changed function.
+ */
+function extractChangedSymbols(diff, file) {
+  const ext = file.split('.').pop().toLowerCase();
+  const lang = EXT_TO_LANG[ext] || 'javascript';
+  const pattern = FUNC_PATTERNS[lang === 'typescript' ? 'ts' : lang] || FUNC_PATTERNS.js;
+
+  const changes = [];
+  const lines = diff.split('\n');
+
+  let baseLineNum = 0;
+  let headLineNum = 0;
+  let currentFunc = null;
+  let beforeLines = [];
+  let afterLines = [];
+  let inFunc = false;
+  let braceDepth = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Hunk header
+    const hunkMatch = line.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+    if (hunkMatch) {
+      // Save previous function if any
+      if (currentFunc && (beforeLines.length > 0 || afterLines.length > 0)) {
+        changes.push({
+          name: currentFunc,
+          file,
+          lang,
+          before: beforeLines.join('\n'),
+          after: afterLines.join('\n'),
+          line: headLineNum,
+        });
+      }
+      baseLineNum = parseInt(hunkMatch[1], 10) - 1;
+      headLineNum = parseInt(hunkMatch[3], 10) - 1;
+      currentFunc = null;
+      beforeLines = [];
+      afterLines = [];
+      inFunc = false;
+      braceDepth = 0;
+      continue;
+    }
+
+    if (line.startsWith('-')) {
+      baseLineNum++;
+      const trimmed = line.slice(1);
+
+      // Check for function definition
+      if (!inFunc) {
+        const match = trimmed.match(pattern);
+        if (match) {
+          currentFunc = match[1] || match[2] || match[3];
+          inFunc = true;
+          beforeLines.push(trimmed);
+        }
+      } else {
+        beforeLines.push(trimmed);
+      }
+    } else if (line.startsWith('+')) {
+      headLineNum++;
+      const trimmed = line.slice(1);
+
+      if (!inFunc) {
+        const match = trimmed.match(pattern);
+        if (match) {
+          currentFunc = match[1] || match[2] || match[3];
+          inFunc = true;
+        }
+      }
+
+      if (inFunc) {
+        afterLines.push(trimmed);
+        // Track brace depth for function body
+        braceDepth += (trimmed.match(/{/g) || []).length - (trimmed.match(/}/g) || []).length;
+        // Function ends when brace depth goes negative (wasn't in body yet) or
+        // when we see a new function definition
+      }
+    } else if (line.startsWith(' ')) {
+      baseLineNum++;
+      headLineNum++;
+
+      // Context line — if we're in a function, include it
+      if (inFunc) {
+        const trimmed = line.slice(1);
+        beforeLines.push(trimmed);
+        afterLines.push(trimmed);
+        braceDepth += (trimmed.match(/{/g) || []).length - (trimmed.match(/}/g) || []).length;
+      }
+
+      // End of function body
+      if (inFunc && braceDepth < 0) {
+        if (currentFunc && (beforeLines.length > 0 || afterLines.length > 0)) {
+          changes.push({
+            name: currentFunc,
+            file,
+            lang,
+            before: beforeLines.join('\n'),
+            after: afterLines.join('\n'),
+            line: headLineNum,
+          });
+        }
+        currentFunc = null;
+        beforeLines = [];
+        afterLines = [];
+        inFunc = false;
+        braceDepth = 0;
+      }
+    }
+  }
+
+  // Don't forget last function
+  if (currentFunc && (beforeLines.length > 0 || afterLines.length > 0)) {
+    changes.push({
+      name: currentFunc,
+      file,
+      lang,
+      before: beforeLines.join('\n'),
+      after: afterLines.join('\n'),
+      line: headLineNum,
+    });
+  }
+
+  return changes;
+}
+
+/**
+ * Build symbol ID from file path and symbol name.
+ * Matches the format used in codebase-index.js.
+ */
+function buildSymbolId(file, name) {
+  return `${file}:${name}`;
+}
+
+/**
+ * Find symbol in base index by name in a specific file.
+ * Returns { symbol, symbolId } or null.
+ */
+function findSymbolInIndex(fileIndex, file, name) {
+  const fileSymbols = fileIndex[file];
+  if (!fileSymbols) return null;
+
+  for (const sym of fileSymbols) {
+    if (sym.name === name) {
+      const symbolId = sym.symbolId || `${file}:${sym.kind || 'func'}:${name}`;
+      return { symbol: sym, symbolId };
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Phase A: Ref-Based Triage
+// ---------------------------------------------------------------------------
+
+/**
+ * Phase A triage using codebase-index refs[] data.
+ *
+ * @param {Array} changedSymbols - [{name, file, lang, before, after, line}]
+ * @param {Object} baseIndexData - loaded index data with refs
+ * @returns {{ llmCandidates: Array, skipped: Array }}
+ */
+function phaseATriage(changedSymbols, baseIndexData) {
+  const { files: fileIndex, refs } = baseIndexData;
+  const llmCandidates = [];
+  const skipped = [];
+
+  for (const candidate of changedSymbols) {
+    const { name, file, before, after, lang } = candidate;
+
+    // Build possible symbol IDs to look up
+    const possibleIds = [
+      `${file}:${name}`,
+      `${file}:func:${name}`,
+      `${file}:${lang}:${name}`,
+    ];
+
+    let symbolId = null;
+    let symbolData = null;
+
+    for (const sid of possibleIds) {
+      if (refs[sid]) {
+        symbolId = sid;
+        symbolData = { symbolId: sid };
+        break;
+      }
+    }
+
+    // Also try searching by name in the file's symbols
+    if (!symbolId) {
+      const found = findSymbolInIndex(fileIndex, file, name);
+      if (found) {
+        symbolId = found.symbolId;
+        symbolData = found;
+      }
+    }
+
+    if (!symbolId || !refs[symbolId]) {
+      // Cannot resolve to base index → send to LLM (conservative)
+      llmCandidates.push({
+        ...candidate,
+        symbolId: symbolId || `unresolved:${file}:${name}`,
+        triageReason: 'unresolvable',
+      });
+      continue;
+    }
+
+    const symbolRefs = refs[symbolId] || [];
+    const totalRefs = symbolRefs.length;
+
+    if (totalRefs === 0) {
+      // No external callers → low risk, SKIP
+      skipped.push({ ...candidate, symbolId, triageReason: 'no-external-refs' });
+      continue;
+    }
+
+    // Count refs inside PR (we can't know exactly, so estimate based on file)
+    // For triage: if internalRatio > 0.8, skip
+    // We approximate internalRatio by counting refs to the same file
+    const internalRefs = symbolRefs.filter(r => r.file === file).length;
+    const internalRatio = internalRefs / totalRefs;
+
+    if (internalRatio > INTERNAL_RATIO_THRESHOLD) {
+      // Overwhelmingly self-contained → low risk, SKIP
+      skipped.push({ ...candidate, symbolId, internalRatio, triageReason: 'low-external-impact' });
+    } else {
+      // External callers exist → needs LLM check
+      llmCandidates.push({
+        ...candidate,
+        symbolId,
+        internalRatio,
+        totalRefs,
+        triageReason: 'external-callers',
+      });
+    }
+  }
+
+  return { llmCandidates, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// Phase B: LLM Analysis
+// ---------------------------------------------------------------------------
+
+/**
+ * Call LLM to detect unnecessary cleanups in filtered candidates.
+ */
+async function phaseBLLMAnalysis(llmCandidates, issueDescription, sessionKey) {
+  if (llmCandidates.length === 0) return [];
+
+  // Build prompt with before/after snippets
+  const changesText = llmCandidates
+    .map(c => {
+      let entry = `File: ${c.file}\nSymbol: ${c.name}\n`;
+      entry += `Before (original):\n${c.before || '(no before snippet)'}\n\n`;
+      entry += `After (changed):\n${c.after || '(no after snippet)'}\n`;
+      entry += `Triage reason: ${c.triageReason}\n`;
+      return entry;
+    })
+    .join('\n---\n\n');
+
+  const systemPrompt = CLEANUP_SYSTEM_PROMPT.replace('{issue_description}', issueDescription || '(no linked issue)');
+
+  const userPrompt = `Review these code changes for unnecessary cleanup:\n\n${changesText}\n\nOutput JSON with your findings.`;
+
+  let lastError = null;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      const { model } = await resolveModel(sessionKey);
+      const response = await callAI(model, systemPrompt, userPrompt, sessionKey);
+      const trimmed = response.trim();
+      const jsonStr = trimmed.replace(/^```json\s*/i, '').replace(/\s*```$/i, '');
+      const parsed = JSON.parse(jsonStr);
+
+      if (!parsed.cleanups || !Array.isArray(parsed.cleanups)) {
+        throw new Error('Invalid schema: cleanups not array');
+      }
+
+      return parsed.cleanups
+        .filter(c => (c.confidence || 0) >= CONFIDENCE_THRESHOLD)
+        .map(c => ({
+          file: c.file,
+          symbol: c.symbol,
+          before: c.before,
+          after: c.after,
+          whyCleanup: c.whyCleanup,
+          whyProblematic: c.whyProblematic,
+          severity: c.severity,
+          suggestion: c.suggestion,
+          confidence: c.confidence,
+        }));
+    } catch (e) {
+      lastError = e;
+      console.error(`[review-cleanup] LLM attempt ${attempt} failed: ${e.message}`);
+    }
+  }
+
+  console.error(`[review-cleanup] LLM failed after 2 attempts: ${lastError.message}`);
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Main entry point: detect unnecessary cleanup in a PR.
+ *
+ * @param {number} prNum - PR number
+ * @param {string} baseBranch - Target branch (e.g. 'main')
+ * @param {string} worktreePath - Worktree path for git operations
+ * @param {string} repo - "owner/repo"
+ * @param {GitHubClient} client - GitHub API client
+ * @param {string} sessionKey - Session key for LLM calls
+ * @param {string|null} issueDescription - Linked issue description (for LLM context)
+ * @returns {Promise<{ cleanups: Array, llmCandidates: Array, skipped: Array, modifiedFiles: number }>}
+ */
+export async function detectUnnecessaryCleanup(prNum, baseBranch, worktreePath, repo, client, sessionKey, issueDescription = null) {
+  console.log(`[review-cleanup] Starting for PR #${prNum} (base: ${baseBranch})`);
+
+  // If no linked issue, skip (not a real PR for cleanup detection purposes)
+  if (!issueDescription) {
+    console.log(`[review-cleanup] No linked issue — skipping Step 2`);
+    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0, noLinkedIssue: true };
+  }
+
+  // Ensure base branch index is fresh
+  const freshness = checkIndexFreshness(repo, baseBranch, worktreePath);
+  console.log(`[review-cleanup] Freshness: ${freshness.fresh} (indexed: ${freshness.indexedCommit?.slice(0, 7)}, current: ${freshness.currentCommit?.slice(0, 7)})`);
+
+  if (!freshness.fresh) {
+    console.log(`[review-cleanup] Index stale, rebuilding for ${baseBranch}...`);
+    getOrBuildIndex(worktreePath, repo, baseBranch);
+  }
+
+  // Load base branch index
+  const baseIndexData = loadIndex(repo, baseBranch);
+  if (!baseIndexData || !baseIndexData.files || Object.keys(baseIndexData.files).length === 0) {
+    console.log(`[review-cleanup] No index found for ${repo}@${baseBranch}`);
+    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0 };
+  }
+
+  // Get PR head ref
+  let headRef;
+  try {
+    const prDetails = await client.request('GET', `/repos/${repo}/pulls/${prNum}`);
+    headRef = prDetails.head?.ref;
+  } catch (e) {
+    console.error(`[review-cleanup] Failed to get PR head ref: ${e.message}`);
+    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0 };
+  }
+
+  if (!headRef) {
+    console.log(`[review-cleanup] No head ref for PR #${prNum}`);
+    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0 };
+  }
+
+  // Phase A: Get modified files and extract changed symbols
+  const modifiedFiles = getModifiedFiles(worktreePath, baseBranch, headRef);
+  console.log(`[review-cleanup] Modified files (excluding new): ${modifiedFiles.length}`);
+
+  if (modifiedFiles.length === 0) {
+    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: 0 };
+  }
+
+  const allChangedSymbols = [];
+  for (const file of modifiedFiles) {
+    try {
+      const diff = exec(
+        `git diff origin/${baseBranch}..origin/${headRef} -- "${file}"`,
+        { cwd: worktreePath, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+      );
+      const symbols = extractChangedSymbols(diff, file);
+      allChangedSymbols.push(...symbols);
+    } catch (e) {
+      console.error(`[review-cleanup] Failed to diff ${file}: ${e.message}`);
+    }
+  }
+
+  console.log(`[review-cleanup] Changed symbols extracted: ${allChangedSymbols.length}`);
+
+  if (allChangedSymbols.length === 0) {
+    return { cleanups: [], llmCandidates: [], skipped: [], modifiedFiles: modifiedFiles.length };
+  }
+
+  // Phase A: Ref-based triage
+  const { llmCandidates, skipped } = phaseATriage(allChangedSymbols, baseIndexData);
+  console.log(`[review-cleanup] Phase A triage: ${llmCandidates.length} → LLM, ${skipped.length} skipped`);
+
+  // Phase B: LLM Analysis
+  const cleanups = await phaseBLLMAnalysis(llmCandidates, issueDescription, sessionKey);
+  console.log(`[review-cleanup] Phase B LLM found ${cleanups.length} cleanups`);
+
+  return {
+    cleanups,
+    llmCandidates,
+    skipped,
+    modifiedFiles: modifiedFiles.length,
+  };
+}

--- a/utils/review-cleanup.js
+++ b/utils/review-cleanup.js
@@ -234,7 +234,7 @@ function extractChangedSymbols(diff, file) {
  * @returns {{ llmCandidates: Array, skipped: Array }}
  */
 function phaseATriage(changedSymbols, baseIndexData) {
-  const { files: fileIndex, refs } = baseIndexData;
+  const { refs } = baseIndexData;
   const llmCandidates = [];
   const skipped = [];
 


### PR DESCRIPTION
Fixes: #108

## Summary

Add **Step 2: detectUnnecessaryCleanup()** to the PR review flow, running in parallel with existing `detectReuse()`. This step detects when changes make code "more standard/modern/elegant" rather than fixing the actual issue.

## What Changed

- **Phase A — Ref-Based Triage**: Filter candidates using `codebase-index.js` refs data
  - Skip if `totalRefs == 0` (no external callers)
  - Skip if `internalRatio > 0.8` (overwhelmingly self-contained)
  - Send remaining to Phase B for LLM analysis

- **Phase B — LLM Analysis**: Analyze filtered candidates for unnecessary cleanup patterns:
  - "Unusual" pattern replaced with "standard" one
  - Manual implementation replaced with library call
  - Older style replaced with newer style
  - Longer form replaced with shorter form

- **Output**: New "🧹 Unnecessary Cleanup Check" section in review comments with severity ratings

- **Label Integration**: `gtw/revise` triggered for critical/high severity cleanups (independent of Step 1)

## Why

AI agents tend to rewrite "non-standard" code patterns to conventional ones, introducing subtle bugs when the original code was intentional (historical reasons, performance tuning, compatibility workarounds). The current system only catches duplicate/new code, not this scope creep pattern.

## Scope

- Only MODIFIED files checked (new files/deletions excluded)
- Confidence threshold >= 0.80 for reporting
- Token efficient: large PRs (50+ files) → only 1-3 LLM calls after Phase A filtering

## How to Test

```bash
gtw review <pr-with-style-changes>
```

Verify:
1. ✅ Ref triage skips symbols with >80% internal refs without LLM call
2. ✅ New files excluded from cleanup detection
3. ✅ Only confidence >= 0.80 changes reported
4. ✅ Critical/high → `gtw/revise` label applied
5. ✅ Graceful handling when no linked issue (Step 2 skipped with note)

## Summary by Sourcery

Integrate an unnecessary cleanup detection step into the PR review workflow, running alongside existing duplicate detection and influencing review output and labeling.

New Features:
- Add detectUnnecessaryCleanup step that analyzes modified symbols for stylistic cleanups not required by the linked issue using a two-phase ref-triage and LLM-based analysis.
- Include a new "🧹 Unnecessary Cleanup Check" section in the PR review comment summarizing analyzed files, triage outcomes, and detailed findings with severity and suggestions.

Enhancements:
- Run duplicate detection and unnecessary cleanup detection in parallel and incorporate both into the final review verdict and summary, including label decisions and stored review metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated "Unnecessary Cleanup" detection to PR reviews
  * Reviews now run reuse and cleanup checks concurrently

* **Improvements**
  * PR verdicts consider cleanup findings (including errors) when requiring revisions
  * Review summaries and comments now include cleanup metrics, counts, and highlighted critical/high items
<!-- end of auto-generated comment: release notes by coderabbit.ai -->