### PR TITLE
fix(gtw): align review verdict and PR label with published comment

### DIFF
--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -294,17 +294,16 @@ export class ReviewCommand extends Commander {
   }
 
   _buildComment(prNum, prData, results, cleanupResults = {}) {
+    const { reuseIcon, cleanupIcon, totalReuseIssues, totalCleanupIssues } = computeReviewIcons(
+      results,
+      cleanupResults
+    );
     const items = results.items || [];
     const cleanups = cleanupResults.cleanups || [];
-
-    const totalReuseIssues = items.length;
-    const totalCleanupIssues = cleanups.length;
 
     let comment = '## GTW Code Review\n\n';
 
     // Status line: ☑️ when no issues, ❌ when issues present
-    const reuseIcon = totalReuseIssues === 0 ? '☑️' : '❌';
-    const cleanupIcon = totalCleanupIssues === 0 ? '☑️' : '❌';
     const reuseCount = totalReuseIssues > 0 ? ` (${totalReuseIssues})` : '';
     const cleanupCount = totalCleanupIssues > 0 ? ` (${totalCleanupIssues})` : '';
     comment += `${reuseIcon} Reuse Review${reuseCount} | ${cleanupIcon} Cleanup Review${cleanupCount}\n\n`;

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -260,10 +260,10 @@ export class ReviewCommand extends Commander {
     // Separator
     comment += '---\n\n';
 
-    // Reuse Review findings grouped by severity
-    const criticalItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'critical');
+    // Reuse Review findings grouped by severity (all verdict types grouped by severity only)
+    const criticalItems = items.filter((i) => i.severity === 'critical');
     const highItems = items.filter((i) => i.severity === 'high');
-    const mediumItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'medium');
+    const mediumItems = items.filter((i) => i.severity === 'medium');
     const lowItems = items.filter((i) => i.severity === 'low');
 
     if (criticalItems.length > 0 || highItems.length > 0 || mediumItems.length > 0 || lowItems.length > 0) {

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -236,35 +236,24 @@ export class ReviewCommand extends Commander {
     };
   }
 
+  _sanitizeCell(value) {
+    if (value == null) return '';
+    return String(value).replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
+  }
+
   _buildComment(prNum, prData, results, cleanupResults = {}) {
     const items = results.items || [];
     const cleanups = cleanupResults.cleanups || [];
 
-    // Count duplicates by severity
-    const duplicateCounts = {
-      critical: items.filter((i) => i.verdict === 'duplicate' && i.severity === 'critical').length,
-      high: items.filter((i) => i.verdict === 'duplicate' && i.severity === 'high').length,
-      medium: items.filter((i) => i.verdict === 'duplicate' && i.severity === 'medium').length,
-      low: items.filter((i) => i.severity === 'low' && ['similar', 'pattern'].includes(i.verdict)).length,
-    };
-
-    // Count cleanups by severity
-    const cleanupCounts = {
-      critical: cleanups.filter((c) => c.severity === 'critical').length,
-      high: cleanups.filter((c) => c.severity === 'high').length,
-      medium: cleanups.filter((c) => c.severity === 'medium').length,
-      low: cleanups.filter((c) => c.severity === 'low').length,
-    };
-
-    const totalDuplicateIssues = items.filter((i) => i.verdict === 'duplicate').length;
+    const totalReuseIssues = items.length;
     const totalCleanupIssues = cleanups.length;
 
     let comment = '## GTW Code Review\n\n';
 
     // Status line: ☑️ when no issues, ❌ when issues present
-    const reuseIcon = totalDuplicateIssues === 0 ? '☑️' : '❌';
+    const reuseIcon = totalReuseIssues === 0 ? '☑️' : '❌';
     const cleanupIcon = totalCleanupIssues === 0 ? '☑️' : '❌';
-    const reuseCount = totalDuplicateIssues > 0 ? ` (${totalDuplicateIssues})` : '';
+    const reuseCount = totalReuseIssues > 0 ? ` (${totalReuseIssues})` : '';
     const cleanupCount = totalCleanupIssues > 0 ? ` (${totalCleanupIssues})` : '';
     comment += `${reuseIcon} Reuse Review${reuseCount} | ${cleanupIcon} Cleanup Review${cleanupCount}\n\n`;
 
@@ -272,109 +261,110 @@ export class ReviewCommand extends Commander {
     comment += '---\n\n';
 
     // Reuse Review findings grouped by severity
-    if (items.length > 0) {
+    const criticalItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'critical');
+    const highItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'high');
+    const mediumItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'medium');
+    const lowItems = items.filter((i) => i.severity === 'low' && ['similar', 'pattern'].includes(i.verdict));
+
+    if (criticalItems.length > 0 || highItems.length > 0 || mediumItems.length > 0 || lowItems.length > 0) {
       comment += '### Reuse\n\n';
 
       // Critical
-      const criticalItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'critical');
       if (criticalItems.length > 0) {
         comment += '#### Critical\n\n';
         comment += '| Function | File | Symbol | Reason |\n';
         comment += '|----------|------|--------|--------|\n';
         for (const item of criticalItems) {
-          comment += `| ${item.newFunc} | ${item.existingFile || '-'} | ${item.existingFunc} | ${item.reason} |\n`;
+          comment += `| ${this._sanitizeCell(item.newFunc)} | ${this._sanitizeCell(item.existingFile || '-')} | ${this._sanitizeCell(item.existingFunc)} | ${this._sanitizeCell(item.reason)} |\n`;
         }
         comment += '\n';
       }
 
       // High
-      const highItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'high');
       if (highItems.length > 0) {
         comment += '#### High\n\n';
         comment += '| Function | File | Symbol | Reason |\n';
         comment += '|----------|------|--------|--------|\n';
         for (const item of highItems) {
-          comment += `| ${item.newFunc} | ${item.existingFile || '-'} | ${item.existingFunc} | ${item.reason} |\n`;
+          comment += `| ${this._sanitizeCell(item.newFunc)} | ${this._sanitizeCell(item.existingFile || '-')} | ${this._sanitizeCell(item.existingFunc)} | ${this._sanitizeCell(item.reason)} |\n`;
         }
         comment += '\n';
       }
 
       // Medium
-      const mediumItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'medium');
       if (mediumItems.length > 0) {
         comment += '#### Medium\n\n';
         comment += '| Function | File | Symbol | Reason |\n';
         comment += '|----------|------|--------|--------|\n';
         for (const item of mediumItems) {
-          comment += `| ${item.newFunc} | ${item.existingFile || '-'} | ${item.existingFunc} | ${item.reason} |\n`;
+          comment += `| ${this._sanitizeCell(item.newFunc)} | ${this._sanitizeCell(item.existingFile || '-')} | ${this._sanitizeCell(item.existingFunc)} | ${this._sanitizeCell(item.reason)} |\n`;
         }
         comment += '\n';
       }
 
       // Low
-      const lowItems = items.filter((i) => i.severity === 'low' && ['similar', 'pattern'].includes(i.verdict));
       if (lowItems.length > 0) {
         comment += '#### Low\n\n';
         comment += '| Function | File | Symbol | Reason |\n';
         comment += '|----------|------|--------|--------|\n';
         for (const item of lowItems) {
-          comment += `| ${item.newFunc} | ${item.existingFile || '-'} | ${item.existingFunc || '-'} | ${item.reason} |\n`;
+          comment += `| ${this._sanitizeCell(item.newFunc)} | ${this._sanitizeCell(item.existingFile || '-')} | ${this._sanitizeCell(item.existingFunc || '-')} | ${this._sanitizeCell(item.reason)} |\n`;
         }
         comment += '\n';
       }
     }
 
     // Cleanup Review findings grouped by severity
-    if (cleanups.length > 0) {
+    const criticalCleanups = cleanups.filter((c) => c.severity === 'critical');
+    const highCleanups = cleanups.filter((c) => c.severity === 'high');
+    const mediumCleanups = cleanups.filter((c) => c.severity === 'medium');
+    const lowCleanups = cleanups.filter((c) => c.severity === 'low');
+
+    if (criticalCleanups.length > 0 || highCleanups.length > 0 || mediumCleanups.length > 0 || lowCleanups.length > 0) {
       comment += '### Cleanup\n\n';
+    }
 
-      // Critical
-      const criticalCleanups = cleanups.filter((c) => c.severity === 'critical');
-      if (criticalCleanups.length > 0) {
-        comment += '#### Critical\n\n';
-        comment += '| File | Symbol | Reason |\n';
-        comment += '|------|--------|--------|\n';
-        for (const c of criticalCleanups) {
-          comment += `| ${c.file} | ${c.symbol} | ${c.whyCleanup} |\n`;
-        }
-        comment += '\n';
+    if (criticalCleanups.length > 0) {
+      comment += '#### Critical\n\n';
+      comment += '| File | Symbol | Reason |\n';
+      comment += '|------|--------|--------|\n';
+      for (const c of criticalCleanups) {
+        comment += `| ${this._sanitizeCell(c.file)} | ${this._sanitizeCell(c.symbol)} | ${this._sanitizeCell(c.whyCleanup)} |\n`;
       }
+      comment += '\n';
+    }
 
-      // High
-      const highCleanups = cleanups.filter((c) => c.severity === 'high');
-      if (highCleanups.length > 0) {
-        comment += '#### High\n\n';
-        comment += '| File | Symbol | Reason |\n';
-        comment += '|------|--------|--------|\n';
-        for (const c of highCleanups) {
-          comment += `| ${c.file} | ${c.symbol} | ${c.whyCleanup} |\n`;
-        }
-        comment += '\n';
+    // High
+    if (highCleanups.length > 0) {
+      comment += '#### High\n\n';
+      comment += '| File | Symbol | Reason |\n';
+      comment += '|------|--------|--------|\n';
+      for (const c of highCleanups) {
+        comment += `| ${this._sanitizeCell(c.file)} | ${this._sanitizeCell(c.symbol)} | ${this._sanitizeCell(c.whyCleanup)} |\n`;
       }
+      comment += '\n';
+    }
 
-      // Medium
-      const mediumCleanups = cleanups.filter((c) => c.severity === 'medium');
-      if (mediumCleanups.length > 0) {
-        comment += '#### Medium\n\n';
-        comment += '| File | Symbol | Reason |\n';
-        comment += '|------|--------|--------|\n';
-        for (const c of mediumCleanups) {
-          comment += `| ${c.file} | ${c.symbol} | ${c.whyCleanup} |\n`;
-        }
-        comment += '\n';
+    // Medium
+    if (mediumCleanups.length > 0) {
+      comment += '#### Medium\n\n';
+      comment += '| File | Symbol | Reason |\n';
+      comment += '|------|--------|--------|\n';
+      for (const c of mediumCleanups) {
+        comment += `| ${this._sanitizeCell(c.file)} | ${this._sanitizeCell(c.symbol)} | ${this._sanitizeCell(c.whyCleanup)} |\n`;
       }
+      comment += '\n';
+    }
 
-      // Low
-      const lowCleanups = cleanups.filter((c) => c.severity === 'low');
-      if (lowCleanups.length > 0) {
-        comment += '#### Low\n\n';
-        comment += '| File | Symbol | Reason |\n';
-        comment += '|------|--------|--------|\n';
-        for (const c of lowCleanups) {
-          comment += `| ${c.file} | ${c.symbol} | ${c.whyCleanup} |\n`;
-        }
-        comment += '\n';
+    // Low
+    if (lowCleanups.length > 0) {
+      comment += '#### Low\n\n';
+      comment += '| File | Symbol | Reason |\n';
+      comment += '|------|--------|--------|\n';
+      for (const c of lowCleanups) {
+        comment += `| ${this._sanitizeCell(c.file)} | ${this._sanitizeCell(c.symbol)} | ${this._sanitizeCell(c.whyCleanup)} |\n`;
       }
+      comment += '\n';
     }
 
     // Reviewer tag

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -164,15 +164,16 @@ export class ReviewCommand extends Commander {
     }
 
     // Determine verdict — both Step 1 and Step 2 verdicts are independent
-    const criticalItems = duplicateResults.items.filter(
-      (i) => i.verdict === 'duplicate' && ['critical', 'high'].includes(i.severity)
-    );
-    const criticalCleanups = (cleanupResults.cleanups || []).filter(
-      (c) => ['critical', 'high'].includes(c.severity)
-    );
+    // NOTE: We base the verdict ONLY on actual findings (items.length, cleanups.length),
+    // NOT on the presence of an error field. Detection functions may error without
+    // producing any findings (e.g., API timeout returns { error, items: [] }), and
+    // such errors should NOT flip the label to gtw/revise. This ensures the published
+    // comment (which uses the same totals for icons) is always consistent with the label.
+    const totalReuseIssues = (duplicateResults.items || []).length;
+    const totalCleanupIssues = (cleanupResults.cleanups || []).length;
 
     let finalLabel = 'gtw/lgtm';
-    if (duplicateResults.error || cleanupResults.error || criticalItems.length > 0 || criticalCleanups.length > 0) {
+    if (totalReuseIssues > 0 || totalCleanupIssues > 0) {
       finalLabel = 'gtw/revise';
     }
 
@@ -197,6 +198,14 @@ export class ReviewCommand extends Commander {
     saveWip({ ...wip, reviewState: newReviewState });
 
     // Build response
+    // Recompute critical findings for summary display (only duplicate verdicts at critical/high severity block)
+    const summaryCriticalItems = (duplicateResults.items || []).filter(
+      (i) => i.verdict === 'duplicate' && ['critical', 'high'].includes(i.severity)
+    );
+    const summaryCriticalCleanups = (cleanupResults.cleanups || []).filter(
+      (c) => ['critical', 'high'].includes(c.severity)
+    );
+
     const verdictEmoji = finalLabel === 'gtw/lgtm' ? '✅' : '⚠️';
     const verdictText = finalLabel === 'gtw/lgtm' ? 'APPROVED' : 'CHANGES NEEDED';
 
@@ -206,21 +215,21 @@ export class ReviewCommand extends Commander {
       prData.pr.title,
       ``,
       `Functions analyzed: ${duplicateResults.newFunctions?.length || 0}`,
-      `Duplicates found: ${criticalItems.length}`,
-      `Unnecessary cleanups: ${criticalCleanups.length}`,
+      `Reuse issues: ${totalReuseIssues}`,
+      `Cleanup issues: ${totalCleanupIssues}`,
     ];
 
-    if (criticalItems.length > 0) {
-      summary.push(``, `Duplicate functions:`);
-      for (const item of criticalItems) {
+    if (summaryCriticalItems.length > 0) {
+      summary.push(``, `Duplicate functions (critical/high):`);
+      for (const item of summaryCriticalItems) {
         summary.push(`  - ${item.newFunc} → duplicates ${item.existingFunc}`);
         summary.push(`    Reason: ${item.reason}`);
       }
     }
 
-    if (criticalCleanups.length > 0) {
-      summary.push(``, `Unnecessary cleanups:`);
-      for (const cleanup of criticalCleanups) {
+    if (summaryCriticalCleanups.length > 0) {
+      summary.push(``, `Cleanup issues (critical/high):`);
+      for (const cleanup of summaryCriticalCleanups) {
         summary.push(`  - ${cleanup.symbol} in ${cleanup.file}: ${cleanup.whyCleanup}`);
       }
     }

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -262,7 +262,7 @@ export class ReviewCommand extends Commander {
 
     // Reuse Review findings grouped by severity
     const criticalItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'critical');
-    const highItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'high');
+    const highItems = items.filter((i) => i.severity === 'high');
     const mediumItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'medium');
     const lowItems = items.filter((i) => i.severity === 'low' && ['similar', 'pattern'].includes(i.verdict));
 

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -20,6 +20,52 @@ import { detectReuse } from '../utils/review-reuse.js';
 import { detectUnnecessaryCleanup } from '../utils/review-cleanup.js';
 import { prepareReviewWorktree } from './ReviewWorktree.js';
 
+/**
+ * Compute verdict and PR label from detection results.
+ * Exported for unit testing — mirrors the inline logic in _reviewPr.
+ *
+ * NOTE: Verdict is based ONLY on items.length and cleanups.length.
+ * Error fields are intentionally ignored (detection may error with zero findings).
+ */
+export function computeReviewVerdict(duplicateResults, cleanupResults) {
+  const items = duplicateResults?.items || [];
+  const cleanups = cleanupResults?.cleanups || [];
+
+  const totalReuseIssues = items.length;
+  const totalCleanupIssues = cleanups.length;
+
+  let finalLabel = 'gtw/lgtm';
+  if (totalReuseIssues > 0 || totalCleanupIssues > 0) {
+    finalLabel = 'gtw/revise';
+  }
+
+  return {
+    finalLabel,
+    totalReuseIssues,
+    totalCleanupIssues,
+    verdictText: finalLabel === 'gtw/lgtm' ? 'APPROVED' : 'CHANGES NEEDED',
+  };
+}
+
+/**
+ * Compute comment icons from detection results.
+ * Exported for unit testing — mirrors the icon logic in _buildComment.
+ */
+export function computeReviewIcons(duplicateResults, cleanupResults) {
+  const items = duplicateResults?.items || [];
+  const cleanups = cleanupResults?.cleanups || [];
+
+  const totalReuseIssues = items.length;
+  const totalCleanupIssues = cleanups.length;
+
+  return {
+    reuseIcon: totalReuseIssues === 0 ? '☑️' : '❌',
+    cleanupIcon: totalCleanupIssues === 0 ? '☑️' : '❌',
+    totalReuseIssues,
+    totalCleanupIssues,
+  };
+}
+
 export class ReviewCommand extends Commander {
   constructor(context) {
     super(context);
@@ -169,13 +215,10 @@ export class ReviewCommand extends Commander {
     // producing any findings (e.g., API timeout returns { error, items: [] }), and
     // such errors should NOT flip the label to gtw/revise. This ensures the published
     // comment (which uses the same totals for icons) is always consistent with the label.
-    const totalReuseIssues = (duplicateResults.items || []).length;
-    const totalCleanupIssues = (cleanupResults.cleanups || []).length;
-
-    let finalLabel = 'gtw/lgtm';
-    if (totalReuseIssues > 0 || totalCleanupIssues > 0) {
-      finalLabel = 'gtw/revise';
-    }
+    const { finalLabel, totalReuseIssues, totalCleanupIssues } = computeReviewVerdict(
+      duplicateResults,
+      cleanupResults
+    );
 
     try {
       await setPrLabel({ prNum, repo, client, isPR: true }, finalLabel);

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -264,7 +264,7 @@ export class ReviewCommand extends Commander {
     const criticalItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'critical');
     const highItems = items.filter((i) => i.severity === 'high');
     const mediumItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'medium');
-    const lowItems = items.filter((i) => i.severity === 'low' && ['similar', 'pattern'].includes(i.verdict));
+    const lowItems = items.filter((i) => i.severity === 'low');
 
     if (criticalItems.length > 0 || highItems.length > 0 || mediumItems.length > 0 || lowItems.length > 0) {
       comment += '### Reuse\n\n';

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -238,159 +238,147 @@ export class ReviewCommand extends Commander {
 
   _buildComment(prNum, prData, results, cleanupResults = {}) {
     const items = results.items || [];
+    const cleanups = cleanupResults.cleanups || [];
 
-    // Categorize items by verdict and severity
-    const criticalItems = items.filter(
-      (i) => i.verdict === 'duplicate' && ['critical', 'high'].includes(i.severity)
-    );
-    const similarItems = items.filter((i) => i.verdict === 'similar');
-    const internalDuplicates = items.filter((i) => i.verdict === 'internal-duplicate');
-    const patternItems = items.filter((i) => i.verdict === 'pattern');
-    const mediumItems = items.filter(
-      (i) => i.verdict === 'duplicate' && i.severity === 'medium'
-    );
-    const lowItems = items.filter(
-      (i) => i.severity === 'low' && ['similar', 'pattern'].includes(i.verdict)
-    );
-
-    // Summary counts
-    const summary = {
-      critical: items.filter((i) => i.severity === 'critical').length,
-      high: items.filter((i) => i.severity === 'high').length,
-      medium: items.filter((i) => i.severity === 'medium').length,
-      low: items.filter((i) => i.severity === 'low').length,
-      internal: internalDuplicates.length,
+    // Count duplicates by severity
+    const duplicateCounts = {
+      critical: items.filter((i) => i.verdict === 'duplicate' && i.severity === 'critical').length,
+      high: items.filter((i) => i.verdict === 'duplicate' && i.severity === 'high').length,
+      medium: items.filter((i) => i.verdict === 'duplicate' && i.severity === 'medium').length,
+      low: items.filter((i) => i.severity === 'low' && ['similar', 'pattern'].includes(i.verdict)).length,
     };
 
-    let comment = '## 🔍 Code Reuse Review — PR #' + prNum + '\n\n';
-    comment += '**PR:** #' + prNum + ' — ' + prData.pr.title + '\n';
-    comment += '**Base:** ' + prData.baseBranch + '\n\n';
+    // Count cleanups by severity
+    const cleanupCounts = {
+      critical: cleanups.filter((c) => c.severity === 'critical').length,
+      high: cleanups.filter((c) => c.severity === 'high').length,
+      medium: cleanups.filter((c) => c.severity === 'medium').length,
+      low: cleanups.filter((c) => c.severity === 'low').length,
+    };
 
-    comment += '### 📊 Summary\n\n';
-    comment += '| Type | Count |\n';
-    comment += '|------|-------|\n';
-    comment += '| 🔴 Critical | ' + summary.critical + ' |\n';
-    comment += '| 🟠 High | ' + summary.high + ' |\n';
-    comment += '| 🟡 Medium | ' + summary.medium + ' |\n';
-    comment += '| 🟢 Low | ' + summary.low + ' |\n';
-    comment += '| 💡 Internal Duplicates | ' + summary.internal + ' |\n\n';
+    const totalDuplicateIssues = items.filter((i) => i.verdict === 'duplicate').length;
+    const totalCleanupIssues = cleanups.length;
 
-    comment += '### Functions Analyzed: ' + (results.newFunctions?.length || 0) + '\n\n';
+    let comment = '## GTW Code Review\n\n';
 
-    // Critical duplicates
-    if (criticalItems.length > 0) {
-      comment += '### 🚨 Critical Duplicates (' + criticalItems.length + ')\n\n';
-      for (const item of criticalItems) {
-        const severityEmoji = item.severity === 'critical' ? '🔴' : '🟠';
-        comment += '**' + severityEmoji + ' `' + item.newFunc + '`** (' + item.existingFunc + ')\n';
-        comment += '> ' + item.reason + '\n\n';
-        if (item.code) {
-          comment += '```\n' + item.code.slice(0, 200) + (item.code.length > 200 ? '...' : '') + '\n```\n\n';
-        }
-      }
-    }
+    // Status line: ☑️ when no issues, ❌ when issues present
+    const reuseIcon = totalDuplicateIssues === 0 ? '☑️' : '❌';
+    const cleanupIcon = totalCleanupIssues === 0 ? '☑️' : '❌';
+    const reuseCount = totalDuplicateIssues > 0 ? ` (${totalDuplicateIssues})` : '';
+    const cleanupCount = totalCleanupIssues > 0 ? ` (${totalCleanupIssues})` : '';
+    comment += `${reuseIcon} Reuse Review${reuseCount} | ${cleanupIcon} Cleanup Review${cleanupCount}\n\n`;
 
-    // Similar patterns
-    if (similarItems.length > 0) {
-      comment += '### ⚠️ Similar Patterns (' + similarItems.length + ')\n\n';
-      for (const item of similarItems) {
-        comment += '- **`' + item.newFunc + '`** → similar to **`' + item.existingFunc + '`**: ' + item.reason + '\n';
-      }
-      comment += '\n';
-    }
+    // Separator
+    comment += '---\n\n';
 
-    // Internal duplicates
-    if (internalDuplicates.length > 0) {
-      comment += '### 💡 Internal Duplicates (' + internalDuplicates.length + ')\n\n';
-      for (const item of internalDuplicates) {
-        const occurrences = item.occurrences || [{ file: 'unknown', line: 0 }];
-        const locList = occurrences.map((o) => '  - ' + o.file + ':' + o.line).join('\n');
-        comment += '**`' + item.newFunc + '`** appears ' + occurrences.length + '× in this PR:\n' + locList + '\n';
-        comment += '> ' + item.reason + '\n\n';
-      }
-    }
+    // Reuse Review findings grouped by severity
+    if (items.length > 0) {
+      comment += '### Reuse\n\n';
 
-    // Pattern anti-patterns
-    if (patternItems.length > 0) {
-      comment += '### 🔧 Pattern Anti-Patterns (' + patternItems.length + ')\n\n';
-      for (const item of patternItems) {
-        comment += '- **`' + item.newFunc + '`**: ' + item.reason + '\n';
-      }
-      comment += '\n';
-    }
-
-    // Medium severity
-    if (mediumItems.length > 0) {
-      comment += '### 🟡 Medium Priority (' + mediumItems.length + ')\n\n';
-      for (const item of mediumItems) {
-        comment += '- **`' + item.newFunc + '`** → ' + item.existingFunc + ': ' + item.reason + '\n';
-      }
-      comment += '\n';
-    }
-
-    // Low priority
-    if (lowItems.length > 0) {
-      comment += '### 🟢 Low Priority (' + lowItems.length + ')\n\n';
-      for (const item of lowItems) {
-        comment += '- **`' + item.newFunc + '`**: ' + item.reason + '\n';
-      }
-      comment += '\n';
-    }
-
-    if (items.length === 0) {
-      comment += '✅ **No duplicates, similar functions, or patterns found.**\n\n';
-    }
-
-    // Step 2: Unnecessary Cleanup section
-    const cleanups = cleanupResults.cleanups || [];
-    const skipped = cleanupResults.skipped || [];
-    const llmCandidates = cleanupResults.llmCandidates || [];
-    const modifiedFiles = cleanupResults.modifiedFiles || 0;
-    const noLinkedIssue = cleanupResults.noLinkedIssue || false;
-
-    comment += '\n\n### 🧹 Unnecessary Cleanup Check\n\n';
-
-    if (noLinkedIssue) {
-      comment += '*Step 2 skipped: no linked issue found for context.*\n\n';
-    } else {
-      comment += '**Phase A — Ref Triage:**\n';
-      comment += `- Files analyzed: ${modifiedFiles}\n`;
-      comment += `- Sent to LLM: ${llmCandidates.length}\n`;
-      comment += `- Skipped (low risk): ${skipped.length}\n\n`;
-
-      const criticalCleanups = cleanups.filter((c) => ['critical', 'high'].includes(c.severity));
-
-      if (cleanups.length > 0) {
-        comment += '**Findings:**\n\n';
-        comment += '| File | Change | Severity | Suggestion |\n';
-        comment += '|------|--------|----------|------------|\n';
-        for (const c of cleanups) {
-          const severityBadge = c.severity === 'critical' ? '🔴 critical' :
-            c.severity === 'high' ? '🟠 high' :
-            c.severity === 'medium' ? '🟡 medium' : '🟢 low';
-          const toCell = (v) => String(v || '').replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
-          const whyCleanup = toCell(c.whyCleanup);
-          const suggestion = toCell(c.suggestion);
-          comment += `| ${c.file} | ${c.symbol}: ${whyCleanup} | ${severityBadge} | ${suggestion} |\n`;
+      // Critical
+      const criticalItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'critical');
+      if (criticalItems.length > 0) {
+        comment += '#### Critical\n\n';
+        comment += '| Function | File | Symbol | Reason |\n';
+        comment += '|----------|------|--------|--------|\n';
+        for (const item of criticalItems) {
+          comment += `| ${item.newFunc} | ${item.existingFile || '-'} | ${item.existingFunc} | ${item.reason} |\n`;
         }
         comment += '\n';
+      }
 
-        if (criticalCleanups.length > 0) {
-          comment += '**🚨 Critical/High Cleanups:**\n\n';
-          for (const c of criticalCleanups) {
-            const severityEmoji = c.severity === 'critical' ? '🔴' : '🟠';
-            comment += `**${severityEmoji} \`${c.symbol}\`** in ${c.file}\n`;
-            comment += `> Before: ${c.before?.slice(0, 100) || '(empty)'}${c.before?.length > 100 ? '...' : ''}\n`;
-            comment += `> After: ${c.after?.slice(0, 100) || '(empty)'}${c.after?.length > 100 ? '...' : ''}\n`;
-            comment += `> Why problematic: ${c.whyProblematic}\n\n`;
-          }
+      // High
+      const highItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'high');
+      if (highItems.length > 0) {
+        comment += '#### High\n\n';
+        comment += '| Function | File | Symbol | Reason |\n';
+        comment += '|----------|------|--------|--------|\n';
+        for (const item of highItems) {
+          comment += `| ${item.newFunc} | ${item.existingFile || '-'} | ${item.existingFunc} | ${item.reason} |\n`;
         }
-      } else {
-        comment += '✅ **No unnecessary cleanups detected.**\n\n';
+        comment += '\n';
+      }
+
+      // Medium
+      const mediumItems = items.filter((i) => i.verdict === 'duplicate' && i.severity === 'medium');
+      if (mediumItems.length > 0) {
+        comment += '#### Medium\n\n';
+        comment += '| Function | File | Symbol | Reason |\n';
+        comment += '|----------|------|--------|--------|\n';
+        for (const item of mediumItems) {
+          comment += `| ${item.newFunc} | ${item.existingFile || '-'} | ${item.existingFunc} | ${item.reason} |\n`;
+        }
+        comment += '\n';
+      }
+
+      // Low
+      const lowItems = items.filter((i) => i.severity === 'low' && ['similar', 'pattern'].includes(i.verdict));
+      if (lowItems.length > 0) {
+        comment += '#### Low\n\n';
+        comment += '| Function | File | Symbol | Reason |\n';
+        comment += '|----------|------|--------|--------|\n';
+        for (const item of lowItems) {
+          comment += `| ${item.newFunc} | ${item.existingFile || '-'} | ${item.existingFunc || '-'} | ${item.reason} |\n`;
+        }
+        comment += '\n';
       }
     }
 
-        comment += '---\n*Reviewed by gtw*';
+    // Cleanup Review findings grouped by severity
+    if (cleanups.length > 0) {
+      comment += '### Cleanup\n\n';
+
+      // Critical
+      const criticalCleanups = cleanups.filter((c) => c.severity === 'critical');
+      if (criticalCleanups.length > 0) {
+        comment += '#### Critical\n\n';
+        comment += '| File | Symbol | Reason |\n';
+        comment += '|------|--------|--------|\n';
+        for (const c of criticalCleanups) {
+          comment += `| ${c.file} | ${c.symbol} | ${c.whyCleanup} |\n`;
+        }
+        comment += '\n';
+      }
+
+      // High
+      const highCleanups = cleanups.filter((c) => c.severity === 'high');
+      if (highCleanups.length > 0) {
+        comment += '#### High\n\n';
+        comment += '| File | Symbol | Reason |\n';
+        comment += '|------|--------|--------|\n';
+        for (const c of highCleanups) {
+          comment += `| ${c.file} | ${c.symbol} | ${c.whyCleanup} |\n`;
+        }
+        comment += '\n';
+      }
+
+      // Medium
+      const mediumCleanups = cleanups.filter((c) => c.severity === 'medium');
+      if (mediumCleanups.length > 0) {
+        comment += '#### Medium\n\n';
+        comment += '| File | Symbol | Reason |\n';
+        comment += '|------|--------|--------|\n';
+        for (const c of mediumCleanups) {
+          comment += `| ${c.file} | ${c.symbol} | ${c.whyCleanup} |\n`;
+        }
+        comment += '\n';
+      }
+
+      // Low
+      const lowCleanups = cleanups.filter((c) => c.severity === 'low');
+      if (lowCleanups.length > 0) {
+        comment += '#### Low\n\n';
+        comment += '| File | Symbol | Reason |\n';
+        comment += '|------|--------|--------|\n';
+        for (const c of lowCleanups) {
+          comment += `| ${c.file} | ${c.symbol} | ${c.whyCleanup} |\n`;
+        }
+        comment += '\n';
+      }
+    }
+
+    // Reviewer tag
+    comment += '*Reviewed by gtw*';
 
     return comment;
   }
@@ -399,7 +387,7 @@ export class ReviewCommand extends Commander {
     // Find existing comment by bot
     const comments = await client.request('GET', `/repos/${repo}/issues/${prNum}/comments`);
     const myLogin = (await client.request('GET', '/user')).login;
-    const existing = comments.find((c) => c.user?.login === myLogin && c.body?.includes('## 🔍 Code Reuse Review'));
+    const existing = comments.find((c) => c.user?.login === myLogin && c.body?.includes('## GTW Code Review'));
 
     if (existing) {
       await client.request('PATCH', `/repos/${repo}/issues/comments/${existing.id}`, {

--- a/commands/ReviewCommand.test.js
+++ b/commands/ReviewCommand.test.js
@@ -1,201 +1,257 @@
 /**
- * Unit tests for ReviewCommand — pure functions.
+ * Unit tests for ReviewCommand — _buildComment format
  * Run: node --test commands/ReviewCommand.test.js
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert';
-// ReviewCommand was rewritten — these tests cover old logic
-// All tests skipped pending new tests for duplicate detection
 
-const CHECKLIST_ITEMS = ['Destructive', 'Out-of-scope'];
+// Import the module to test
+// Since _buildComment is a private method, we test via the class instance
+// We'll create a minimal mock to test _buildComment in isolation
+import { ReviewCommand } from './ReviewCommand.js';
 
-// ---------------------------------------------------------------------------
-// parseChecklistFromComment
-// ---------------------------------------------------------------------------
+function createTestInstance() {
+  // Create a minimal mock context
+  const context = {
+    sessionKey: 'test-session',
+  };
+  return new ReviewCommand(context);
+}
 
-describe.skip('parseChecklistFromComment', () => {
-  it.skip('parses unchecked items', () => {
-    const body = '## Review [Round 1]\n\n  - [ ] Destructive\n  - [ ] Out-of-scope';
-    const items = parseChecklistFromComment(body);
-    assert.strictEqual(items.length, 2);
-    assert.strictEqual(items[0].text, 'Destructive');
-    assert.strictEqual(items[0].checked, false);
-    assert.strictEqual(items[1].text, 'Out-of-scope');
-    assert.strictEqual(items[1].checked, false);
+describe('_buildComment', () => {
+  const instance = createTestInstance();
+
+  // Mock prData
+  const mockPrData = {
+    pr: {
+      number: 202,
+      title: 'Add new feature',
+    },
+    baseBranch: 'main',
+  };
+
+  it('generates comment with exact title "GTW Code Review"', () => {
+    const results = { items: [], newFunctions: [] };
+    const cleanupResults = { cleanups: [] };
+
+    const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+
+    assert.ok(comment.startsWith('## GTW Code Review'), 'Comment must start with "## GTW Code Review"');
+    assert.strictEqual(comment.split('\n')[0], '## GTW Code Review');
   });
 
-  it.skip('parses checked items', () => {
-    const body = '  - [x] Destructive\n  - [ ] Out-of-scope';
-    const items = parseChecklistFromComment(body);
-    assert.strictEqual(items[0].checked, true);
-    assert.strictEqual(items[1].checked, false);
+  it('contains no PR number, PR title, or base branch in body', () => {
+    const results = { items: [], newFunctions: [] };
+    const cleanupResults = { cleanups: [] };
+
+    const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+
+    // Should not contain PR title or base branch
+    assert.ok(!comment.includes('Add new feature'), 'Should not contain PR title');
+    assert.ok(!comment.includes('main'), 'Should not contain base branch "main"');
+    assert.ok(!comment.includes('#202'), 'Should not contain PR number in body');
   });
 
-  it.skip('parses mixed items', () => {
-    const body = '  - [x] Destructive\n  - [x] Out-of-scope';
-    const items = parseChecklistFromComment(body);
-    assert.strictEqual(items.every((i) => i.checked), true);
+  describe('no issues scenario', () => {
+    it('shows ☑️ Reuse Review | ☑️ Cleanup Review when both have zero findings', () => {
+      const results = { items: [], newFunctions: [] };
+      const cleanupResults = { cleanups: [] };
+
+      const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+
+      assert.ok(comment.includes('☑️ Reuse Review | ☑️ Cleanup Review'), 'Should show checkmarks for both');
+    });
+
+    it('contains separator and reviewer tag', () => {
+      const results = { items: [], newFunctions: [] };
+      const cleanupResults = { cleanups: [] };
+
+      const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+
+      assert.ok(comment.includes('---'), 'Should contain separator');
+      assert.ok(comment.includes('*Reviewed by gtw*'), 'Should contain reviewer tag');
+    });
+
+    it('does not contain zero-value statistics', () => {
+      const results = { items: [], newFunctions: [] };
+      const cleanupResults = { cleanups: [] };
+
+      const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+
+      assert.ok(!comment.includes('Functions analyzed:'), 'Should not contain Functions analyzed');
+      assert.ok(!comment.includes('Duplicates found:'), 'Should not contain Duplicates found');
+      assert.ok(!comment.includes('Unnecessary cleanups:'), 'Should not contain Unnecessary cleanups');
+      assert.ok(!comment.includes('0'), 'Should not contain zero counts');
+    });
+
+    it('does not contain "No duplicates" or "No unnecessary cleanups" lines', () => {
+      const results = { items: [], newFunctions: [] };
+      const cleanupResults = { cleanups: [] };
+
+      const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+
+      assert.ok(!comment.includes('No duplicates'), 'Should not contain "No duplicates"');
+      assert.ok(!comment.includes('No unnecessary cleanups'), 'Should not contain "No unnecessary cleanups"');
+    });
   });
 
-  it.skip('ignores non-checkbox lines', () => {
-    const body = '## Review [Round 1]\n\nSome text\n  - [ ] Destructive\n---\n_Agent note_';
-    const items = parseChecklistFromComment(body);
-    assert.strictEqual(items.length, 1);
-    assert.strictEqual(items[0].text, 'Destructive');
+  describe('issues present scenario', () => {
+    it('shows ❌ with count when reuse issues exist', () => {
+      const results = {
+        items: [
+          {
+            verdict: 'duplicate',
+            severity: 'critical',
+            newFunc: 'newFunc',
+            existingFunc: 'existingFunc',
+            existingFile: 'file.go',
+            reason: 'exact match',
+          },
+        ],
+        newFunctions: ['newFunc'],
+      };
+      const cleanupResults = { cleanups: [] };
+
+      const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+
+      assert.ok(comment.includes('❌ Reuse Review (1)'), 'Should show X with count for reuse');
+      assert.ok(comment.includes('☑️ Cleanup Review'), 'Should show checkmark for cleanup');
+    });
+
+    it('shows ❌ with count when cleanup issues exist', () => {
+      const results = { items: [], newFunctions: [] };
+      const cleanupResults = {
+        cleanups: [
+          {
+            severity: 'high',
+            file: 'file.go',
+            symbol: 'myFunc',
+            whyCleanup: 'unnecessary change',
+          },
+        ],
+      };
+
+      const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+
+      assert.ok(comment.includes('☑️ Reuse Review'), 'Should show checkmark for reuse');
+      assert.ok(comment.includes('❌ Cleanup Review (1)'), 'Should show X with count for cleanup');
+    });
+
+    it('shows counts matching actual issue counts', () => {
+      const results = {
+        items: [
+          { verdict: 'duplicate', severity: 'critical', newFunc: 'f1', existingFunc: 'e1', reason: 'r' },
+          { verdict: 'duplicate', severity: 'high', newFunc: 'f2', existingFunc: 'e2', reason: 'r' },
+        ],
+      };
+      const cleanupResults = {
+        cleanups: [
+          { severity: 'medium', file: 'a.go', symbol: 's1', whyCleanup: 'w' },
+          { severity: 'low', file: 'b.go', symbol: 's2', whyCleanup: 'w' },
+          { severity: 'low', file: 'c.go', symbol: 's3', whyCleanup: 'w' },
+        ],
+      };
+
+      const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+
+      assert.ok(comment.includes('❌ Reuse Review (2)'), 'Should show reuse count of 2');
+      assert.ok(comment.includes('❌ Cleanup Review (3)'), 'Should show cleanup count of 3');
+    });
+
+    it('groups findings by severity (Critical/High/Medium/Low)', () => {
+      const results = {
+        items: [
+          { verdict: 'duplicate', severity: 'critical', newFunc: 'c1', existingFunc: 'e1', reason: 'r' },
+          { verdict: 'duplicate', severity: 'high', newFunc: 'h1', existingFunc: 'e2', reason: 'r' },
+          { verdict: 'duplicate', severity: 'medium', newFunc: 'm1', existingFunc: 'e3', reason: 'r' },
+          { verdict: 'pattern', severity: 'low', newFunc: 'l1', existingFunc: 'e4', reason: 'r' },
+        ],
+      };
+      const cleanupResults = { cleanups: [] };
+
+      const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+
+      assert.ok(comment.includes('#### Critical'), 'Should have Critical section');
+      assert.ok(comment.includes('#### High'), 'Should have High section');
+      assert.ok(comment.includes('#### Medium'), 'Should have Medium section');
+      assert.ok(comment.includes('#### Low'), 'Should have Low section');
+    });
+
+    it('displays findings in minimal tables with necessary columns', () => {
+      const results = {
+        items: [
+          {
+            verdict: 'duplicate',
+            severity: 'critical',
+            newFunc: 'myNewFunc',
+            existingFunc: 'myExistingFunc',
+            existingFile: 'utils/helper.go',
+            reason: 'identical implementation',
+          },
+        ],
+      };
+      const cleanupResults = { cleanups: [] };
+
+      const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+
+      assert.ok(comment.includes('| Function |'), 'Should have Function column');
+      assert.ok(comment.includes('| File |'), 'Should have File column');
+      assert.ok(comment.includes('| Symbol |'), 'Should have Symbol column');
+      assert.ok(comment.includes('| Reason |'), 'Should have Reason column');
+      assert.ok(comment.includes('myNewFunc'), 'Should contain newFunc name');
+      assert.ok(comment.includes('myExistingFunc'), 'Should contain existingFunc name');
+    });
+
+    it('does not contain verbose explanatory paragraphs', () => {
+      const results = {
+        items: [
+          {
+            verdict: 'duplicate',
+            severity: 'critical',
+            newFunc: 'f1',
+            existingFunc: 'e1',
+            reason: 'exact match',
+            code: 'func example() {}',
+          },
+        ],
+      };
+      const cleanupResults = { cleanups: [] };
+
+      const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+
+      // Should not contain code blocks
+      assert.ok(!comment.includes('```'), 'Should not contain code blocks');
+      // Should not contain quoted reasons like ">"
+      assert.ok(!comment.includes('> '), 'Should not contain quote markers');
+    });
   });
 
-  it.skip('handles empty body', () => {
-    assert.deepStrictEqual(parseChecklistFromComment(''), []);
-    assert.deepStrictEqual(parseChecklistFromComment('No checkboxes here'), []);
-  });
-});
+  describe('format integrity', () => {
+    it('does not render zero-value statistics even when functions analyzed is 0', () => {
+      const results = { items: [], newFunctions: [] };
+      const cleanupResults = { cleanups: [], modifiedFiles: 0, llmCandidates: [], skipped: [] };
 
-// ---------------------------------------------------------------------------
-// mergeChecklistState
-// Spec: "remove checkboxes that are resolved; keep unresolved ones"
-// Resolved = checked in previous comment → REMOVED from new comment
-// Unresolved = unchecked in previous comment → KEPT in new comment
-// ---------------------------------------------------------------------------
+      const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
 
-describe.skip('mergeChecklistState (AC4: Checklist lifecycle)', () => {
-  it.skip('Round 1: all items unresolved → all kept', () => {
-    const prev = [];
-    const result = mergeChecklistState(prev, CHECKLIST_ITEMS);
-    assert.strictEqual(result.length, 2);
-    assert.ok(result.every((i) => !i.checked));
-  });
+      assert.ok(!comment.match(/Functions analyzed:\s*0/), 'Should not contain Functions analyzed: 0');
+      assert.ok(!comment.match(/Duplicates found:\s*0/), 'Should not contain Duplicates found: 0');
+      assert.ok(!comment.match(/Unnecessary cleanups:\s*0/), 'Should not contain Unnecessary cleanups: 0');
+    });
 
-  it.skip('re-review: resolved items (checked) are removed', () => {
-    // Destructive=[x] (resolved) → removed; Out-of-scope=[ ] (unresolved) → kept
-    const prev = [
-      { text: 'Destructive', checked: true },
-      { text: 'Out-of-scope', checked: false },
-    ];
-    const result = mergeChecklistState(prev, CHECKLIST_ITEMS);
-    assert.strictEqual(result.some((i) => i.text === 'Destructive'), false);
-    const outOfScope = result.find((i) => i.text === 'Out-of-scope');
-    assert.ok(outOfScope);
-    assert.strictEqual(outOfScope.checked, false);
-  });
+    it('status line format starts with emoji and Reuse Review', () => {
+      const results = { items: [], newFunctions: [] };
+      const cleanupResults = { cleanups: [] };
 
-  it.skip('re-review: unresolved items are kept', () => {
-    const prev = [
-      { text: 'Destructive', checked: false },
-      { text: 'Out-of-scope', checked: false },
-    ];
-    const result = mergeChecklistState(prev, CHECKLIST_ITEMS);
-    assert.strictEqual(result.length, 2);
-    assert.ok(result.every((i) => !i.checked));
-  });
+      const comment = instance._buildComment(202, mockPrData, results, cleanupResults);
+      const lines = comment.split('\n');
+      // Status line is at index 2 (after title and empty line)
+      const statusLine = lines[2];
 
-  it.skip('re-review: all resolved → empty list → triggers approval', () => {
-    const prev = [
-      { text: 'Destructive', checked: true },
-      { text: 'Out-of-scope', checked: true },
-    ];
-    const result = mergeChecklistState(prev, CHECKLIST_ITEMS);
-    assert.strictEqual(result.length, 0); // all removed
-    // Approval triggers when: checklistItems.length === 0
-    assert.strictEqual(result.length === 0, true);
-  });
-
-  it.skip('re-review: custom item (not in canonical) is dropped', () => {
-    const prev = [
-      { text: 'Custom Note', checked: true },
-      { text: 'Destructive', checked: false },
-    ];
-    const result = mergeChecklistState(prev, CHECKLIST_ITEMS);
-    assert.strictEqual(result.some((i) => i.text === 'Custom Note'), false);
-    assert.strictEqual(result.find((i) => i.text === 'Destructive')?.checked, false);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Round tracking logic (AC5)
-// ---------------------------------------------------------------------------
-
-describe.skip('Round tracking behavior (AC5)', () => {
-  it.skip('round increments from N to N+1 on each re-review', () => {
-    const extractRound = (body) => {
-      const m = body.match(/## Review \[Round (\d+)\]/);
-      return m ? parseInt(m[1]) : 1;
-    };
-    assert.strictEqual(extractRound('## Review [Round 1]'), 1);
-    assert.strictEqual(extractRound('## Review [Round 5]'), 5);
-    // Next invocation: round + 1
-    assert.strictEqual(extractRound('## Review [Round 5]') + 1, 6);
-  });
-
-  it.skip('stuck triggers when round > maxRounds (default 5)', () => {
-    const DEFAULT_MAX_ROUNDS = 5;
-    const isStuck = (round) => round > DEFAULT_MAX_ROUNDS;
-    assert.strictEqual(isStuck(5), false); // round 5: still OK
-    assert.strictEqual(isStuck(6), true);  // round 6: stuck
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Label constants (AC1)
-// ---------------------------------------------------------------------------
-
-
-// ---------------------------------------------------------------------------
-// Needs-changes behavior (gtw/revise label)
-// Spec: "when changes needed, label gtw/revise (not keep gtw/wip)"
-// ---------------------------------------------------------------------------
-
-describe.skip('Needs-changes: gtw/revise label (AC4 extended)', () => {
-  it.skip('mergeChecklistState: unresolved items remain when some resolved', () => {
-    // Destructive=[x] resolved, Out-of-scope=[ ] unresolved
-    const prev = [
-      { text: 'Destructive', checked: true },
-      { text: 'Out-of-scope', checked: false },
-    ];
-    const result = mergeChecklistState(prev, CHECKLIST_ITEMS);
-    // Destructive removed, Out-of-scope kept
-    assert.strictEqual(result.length, 1);
-    assert.strictEqual(result[0].text, 'Out-of-scope');
-    assert.strictEqual(result[0].checked, false);
-  });
-
-  it.skip('needsChanges: unresolved count > 0 is not same as allResolved', () => {
-    const prev = [
-      { text: 'Destructive', checked: false },
-      { text: 'Out-of-scope', checked: false },
-    ];
-    const result = mergeChecklistState(prev, CHECKLIST_ITEMS);
-    const allResolved = result.length === 0;
-    const needsChanges = result.length > 0;
-    assert.strictEqual(allResolved, false); // 2 unresolved → not all resolved
-    assert.strictEqual(needsChanges, true);  // has unresolved items
-  });
-
-  it.skip('checklist kept when transitioning to gtw/revise (round preserved)', () => {
-    // When gtw/revise is set, checklist comment should be kept
-    // so that round continues to increment on re-review.
-    // The commentId should NOT be deleted.
-    // Simulate: unresolved → gtw/revise transition keeps checklist.
-    const existingComment = {
-      id: 100,
-      body: '## Review [Round 2]\n\n  - [ ] Out-of-scope',
-      user: { login: 'test-agent' },
-    };
-    assert.ok(existingComment.body.includes('## Review [Round 2]'));
-    // After re-review: Round 2 → Round 3
-    const nextRound = 3;
-    assert.ok(existingComment.body.includes(`[Round ${nextRound - 1}]`));
-  });
-});
-
-
-describe.skip('GTW_LABELS (AC1)', () => {
-  it.skip('has exactly 5 mutually exclusive labels', () => {
-    const GTW_LABELS = ['gtw/ready', 'gtw/wip', 'gtw/lgtm', 'gtw/revise', 'gtw/stuck'];
-    assert.strictEqual(GTW_LABELS.length, 5);
-  });
-
-  it.skip('CHECKLIST_ITEMS has exactly 2 canonical items', () => {
-    assert.strictEqual(CHECKLIST_ITEMS.length, 2);
-    assert.deepStrictEqual(CHECKLIST_ITEMS, ['Destructive', 'Out-of-scope']);
+      // Status line should contain emoji + Reuse Review (check for the actual emoji chars)
+      assert.ok(statusLine.includes('Reuse Review'), 'Status line should contain Reuse Review');
+      assert.ok(statusLine.includes('Cleanup Review'), 'Status line should contain Cleanup Review');
+      // Should contain both checkmarks for no issues
+      assert.ok(statusLine.includes('☑️'), 'Should contain checkmark for no issues');
+    });
   });
 });

--- a/test/unit-review-verdict.test.js
+++ b/test/unit-review-verdict.test.js
@@ -1,0 +1,330 @@
+/**
+ * Unit tests for ReviewCommand verdict/label logic consistency
+ *
+ * Tests cover the fix for issue #206:
+ * "fix: align GTW review verdict and PR label with published comment"
+ *
+ * Key behavior:
+ * - The verdict/label must be based solely on items.length and cleanups.length
+ * - Error fields in detection results must NOT cause gtw/revise if findings are zero
+ * - This ensures the published comment icons (☐️/❌) are always consistent with the label
+ */
+
+import { strict as assert } from 'assert';
+
+// ---------------------------------------------------------------------------
+// Pure verdict computation (mirrors the logic in ReviewCommand._reviewPr)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the verdict and label based on detection results.
+ * This is extracted logic for testability.
+ */
+function computeVerdict(duplicateResults, cleanupResults) {
+  const items = duplicateResults?.items || [];
+  const cleanups = cleanupResults?.cleanups || [];
+
+  const totalReuseIssues = items.length;
+  const totalCleanupIssues = cleanups.length;
+
+  let finalLabel = 'gtw/lgtm';
+  if (totalReuseIssues > 0 || totalCleanupIssues > 0) {
+    finalLabel = 'gtw/revise';
+  }
+
+  return {
+    finalLabel,
+    totalReuseIssues,
+    totalCleanupIssues,
+    verdictText: finalLabel === 'gtw/lgtm' ? 'APPROVED' : 'CHANGES NEEDED',
+  };
+}
+
+/**
+ * Build comment icons (mirrors ReviewCommand._buildComment icon logic)
+ */
+function computeCommentIcons(duplicateResults, cleanupResults) {
+  const items = duplicateResults?.items || [];
+  const cleanups = cleanupResults?.cleanups || [];
+
+  const totalReuseIssues = items.length;
+  const totalCleanupIssues = cleanups.length;
+
+  const reuseIcon = totalReuseIssues === 0 ? '☑️' : '❌';
+  const cleanupIcon = totalCleanupIssues === 0 ? '☑️' : '❌';
+
+  return { reuseIcon, cleanupIcon, totalReuseIssues, totalCleanupIssues };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+console.log('🧪 Testing ReviewCommand verdict/label consistency\n');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`✅ ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`❌ ${name}`);
+    console.log(`   Error: ${e.message}`);
+    failed++;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 1: No issues — comment shows ☑️, label gtw/lgtm, verdict APPROVED
+// ---------------------------------------------------------------------------
+
+test('No issues: verdict is APPROVED and label is gtw/lgtm', () => {
+  const duplicateResults = { items: [], newFunctions: [] };
+  const cleanupResults = { cleanups: [] };
+
+  const result = computeVerdict(duplicateResults, cleanupResults);
+
+  assert.strictEqual(result.finalLabel, 'gtw/lgtm', 'Label should be gtw/lgtm');
+  assert.strictEqual(result.verdictText, 'APPROVED', 'Verdict should be APPROVED');
+  assert.strictEqual(result.totalReuseIssues, 0, 'totalReuseIssues should be 0');
+  assert.strictEqual(result.totalCleanupIssues, 0, 'totalCleanupIssues should be 0');
+});
+
+test('No issues: comment icons are both ☑️', () => {
+  const duplicateResults = { items: [], newFunctions: [] };
+  const cleanupResults = { cleanups: [] };
+
+  const icons = computeCommentIcons(duplicateResults, cleanupResults);
+
+  assert.strictEqual(icons.reuseIcon, '☑️', 'Reuse icon should be ☑️');
+  assert.strictEqual(icons.cleanupIcon, '☑️', 'Cleanup icon should be ☑️');
+});
+
+test('No issues: comment icons and label are consistent', () => {
+  const duplicateResults = { items: [], newFunctions: [] };
+  const cleanupResults = { cleanups: [] };
+
+  const verdict = computeVerdict(duplicateResults, cleanupResults);
+  const icons = computeCommentIcons(duplicateResults, cleanupResults);
+
+  // If icons are both ☑️, label must be gtw/lgtm
+  if (icons.reuseIcon === '☑️' && icons.cleanupIcon === '☑️') {
+    assert.strictEqual(verdict.finalLabel, 'gtw/lgtm', 'Label must be gtw/lgtm when icons are ☑️');
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 2: Actual issues present — comment shows ❌, label gtw/revise, verdict CHANGES NEEDED
+// ---------------------------------------------------------------------------
+
+test('Reuse issues present: verdict is CHANGES NEEDED and label is gtw/revise', () => {
+  const duplicateResults = {
+    items: [
+      {
+        newFunc: 'foo',
+        existingFunc: 'bar',
+        verdict: 'duplicate',
+        severity: 'high',
+        reason: 'same functionality',
+      },
+    ],
+    newFunctions: [{ name: 'foo' }],
+  };
+  const cleanupResults = { cleanups: [] };
+
+  const result = computeVerdict(duplicateResults, cleanupResults);
+
+  assert.strictEqual(result.finalLabel, 'gtw/revise', 'Label should be gtw/revise');
+  assert.strictEqual(result.verdictText, 'CHANGES NEEDED', 'Verdict should be CHANGES NEEDED');
+  assert.strictEqual(result.totalReuseIssues, 1, 'totalReuseIssues should be 1');
+  assert.strictEqual(result.totalCleanupIssues, 0, 'totalCleanupIssues should be 0');
+});
+
+test('Cleanup issues present: verdict is CHANGES NEEDED and label is gtw/revise', () => {
+  const duplicateResults = { items: [], newFunctions: [] };
+  const cleanupResults = {
+    cleanups: [
+      {
+        symbol: 'unusedVar',
+        file: 'test.js',
+        severity: 'high',
+        whyCleanup: 'unnecessary cleanup',
+      },
+    ],
+  };
+
+  const result = computeVerdict(duplicateResults, cleanupResults);
+
+  assert.strictEqual(result.finalLabel, 'gtw/revise', 'Label should be gtw/revise');
+  assert.strictEqual(result.verdictText, 'CHANGES NEEDED', 'Verdict should be CHANGES NEEDED');
+  assert.strictEqual(result.totalReuseIssues, 0, 'totalReuseIssues should be 0');
+  assert.strictEqual(result.totalCleanupIssues, 1, 'totalCleanupIssues should be 1');
+});
+
+test('Both issues present: verdict is CHANGES NEEDED and label is gtw/revise', () => {
+  const duplicateResults = {
+    items: [{ newFunc: 'foo', verdict: 'duplicate', severity: 'low', reason: 'x' }],
+    newFunctions: [],
+  };
+  const cleanupResults = {
+    cleanups: [{ symbol: 'x', file: 'y', severity: 'low', whyCleanup: 'z' }],
+  };
+
+  const result = computeVerdict(duplicateResults, cleanupResults);
+
+  assert.strictEqual(result.finalLabel, 'gtw/revise', 'Label should be gtw/revise');
+  assert.strictEqual(result.verdictText, 'CHANGES NEEDED', 'Verdict should be CHANGES NEEDED');
+  assert.strictEqual(result.totalReuseIssues, 1, 'totalReuseIssues should be 1');
+  assert.strictEqual(result.totalCleanupIssues, 1, 'totalCleanupIssues should be 1');
+});
+
+test('Issues present: comment icons are both ❌', () => {
+  const duplicateResults = {
+    items: [{ newFunc: 'foo', verdict: 'duplicate', severity: 'low', reason: 'x' }],
+  };
+  const cleanupResults = {
+    cleanups: [{ symbol: 'x', file: 'y', severity: 'low', whyCleanup: 'z' }],
+  };
+
+  const icons = computeCommentIcons(duplicateResults, cleanupResults);
+
+  assert.strictEqual(icons.reuseIcon, '❌', 'Reuse icon should be ❌');
+  assert.strictEqual(icons.cleanupIcon, '❌', 'Cleanup icon should be ❌');
+});
+
+test('Issues present: comment icons and label are consistent', () => {
+  const duplicateResults = {
+    items: [{ newFunc: 'foo', verdict: 'duplicate', severity: 'low', reason: 'x' }],
+  };
+  const cleanupResults = { cleanups: [] };
+
+  const verdict = computeVerdict(duplicateResults, cleanupResults);
+  const icons = computeCommentIcons(duplicateResults, cleanupResults);
+
+  // If reuse icon is ❌, label must be gtw/revise
+  if (icons.reuseIcon === '❌') {
+    assert.strictEqual(verdict.finalLabel, 'gtw/revise', 'Label must be gtw/revise when reuse icon is ❌');
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 3: Detection function errors but yields zero findings
+// This is the key bug fix: error fields must NOT cause gtw/revise
+// ---------------------------------------------------------------------------
+
+test('detectReuse errors with zero findings: verdict is APPROVED (not CHANGES NEEDED)', () => {
+  // This simulates: API timeout returns { error: "timeout", items: [], newFunctions: [] }
+  const duplicateResults = { error: 'API timeout', items: [], newFunctions: [] };
+  const cleanupResults = { cleanups: [] };
+
+  const result = computeVerdict(duplicateResults, cleanupResults);
+
+  // BUG: Old code would set gtw/revise because duplicateResults.error was truthy
+  // FIX: Should be gtw/lgtm because items.length === 0
+  assert.strictEqual(result.finalLabel, 'gtw/lgtm', 'Label should be gtw/lgtm even with error');
+  assert.strictEqual(result.verdictText, 'APPROVED', 'Verdict should be APPROVED even with error');
+  assert.strictEqual(result.totalReuseIssues, 0, 'totalReuseIssues should be 0');
+});
+
+test('detectUnnecessaryCleanup errors with zero findings: verdict is APPROVED', () => {
+  const duplicateResults = { items: [], newFunctions: [] };
+  const cleanupResults = { error: 'Network error', cleanups: [], llmCandidates: [], skipped: [] };
+
+  const result = computeVerdict(duplicateResults, cleanupResults);
+
+  assert.strictEqual(result.finalLabel, 'gtw/lgtm', 'Label should be gtw/lgtm even with error');
+  assert.strictEqual(result.verdictText, 'APPROVED', 'Verdict should be APPROVED even with error');
+  assert.strictEqual(result.totalCleanupIssues, 0, 'totalCleanupIssues should be 0');
+});
+
+test('Both detection functions error with zero findings: verdict is APPROVED', () => {
+  const duplicateResults = { error: 'timeout', items: [], newFunctions: [] };
+  const cleanupResults = { error: 'network', cleanups: [], llmCandidates: [], skipped: [] };
+
+  const result = computeVerdict(duplicateResults, cleanupResults);
+
+  assert.strictEqual(result.finalLabel, 'gtw/lgtm', 'Label should be gtw/lgtm when both error with zero findings');
+  assert.strictEqual(result.verdictText, 'APPROVED', 'Verdict should be APPROVED');
+});
+
+test('Error with zero findings: comment icons remain ☑️ (consistent with label)', () => {
+  const duplicateResults = { error: 'timeout', items: [], newFunctions: [] };
+  const cleanupResults = { error: 'network', cleanups: [] };
+
+  const verdict = computeVerdict(duplicateResults, cleanupResults);
+  const icons = computeCommentIcons(duplicateResults, cleanupResults);
+
+  // Both icons should be ☑️ because items.length and cleanups.length are 0
+  assert.strictEqual(icons.reuseIcon, '☑️', 'Reuse icon should be ☑️');
+  assert.strictEqual(icons.cleanupIcon, '☑️', 'Cleanup icon should be ☑️');
+  // And label should match
+  assert.strictEqual(verdict.finalLabel, 'gtw/lgtm', 'Label should be gtw/lgtm to match icons');
+});
+
+test('Error with actual findings also present: verdict is CHANGES NEEDED', () => {
+  // Error occurred BUT there are also actual findings
+  const duplicateResults = {
+    error: 'partial failure',
+    items: [{ newFunc: 'foo', verdict: 'duplicate', severity: 'high', reason: 'x' }],
+    newFunctions: [],
+  };
+  const cleanupResults = { cleanups: [] };
+
+  const result = computeVerdict(duplicateResults, cleanupResults);
+
+  // Error + findings = gtw/revise (correctly based on findings)
+  assert.strictEqual(result.finalLabel, 'gtw/revise', 'Label should be gtw/revise when findings exist');
+  assert.strictEqual(result.verdictText, 'CHANGES NEEDED', 'Verdict should be CHANGES NEEDED');
+  assert.strictEqual(result.totalReuseIssues, 1, 'totalReuseIssues should be 1');
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+test('Null/undefined items treated as empty array', () => {
+  const duplicateResults = { items: null };
+  const cleanupResults = { cleanups: undefined };
+
+  const result = computeVerdict(duplicateResults, cleanupResults);
+
+  assert.strictEqual(result.finalLabel, 'gtw/lgtm', 'Null/undefined items should be treated as empty');
+  assert.strictEqual(result.totalReuseIssues, 0, 'Null items should count as 0');
+  assert.strictEqual(result.totalCleanupIssues, 0, 'Undefined cleanups should count as 0');
+});
+
+test('Empty items arrays are distinct from missing items property', () => {
+  const results1 = computeVerdict({}, {});
+  const results2 = computeVerdict({ items: [] }, { cleanups: [] });
+
+  // Both should be APPROVED
+  assert.strictEqual(results1.finalLabel, 'gtw/lgtm');
+  assert.strictEqual(results2.finalLabel, 'gtw/lgtm');
+});
+
+test('Low severity items still trigger gtw/revise (all items count)', () => {
+  // Low severity items are shown in comment but don't appear in summary
+  // The verdict should still be CHANGES NEEDED because items.length > 0
+  const duplicateResults = {
+    items: [{ newFunc: 'foo', verdict: 'pattern', severity: 'low', reason: 'anti-pattern' }],
+  };
+  const cleanupResults = { cleanups: [] };
+
+  const result = computeVerdict(duplicateResults, cleanupResults);
+
+  // The issue says verdict is based on totals, so any item should trigger revise
+  assert.strictEqual(result.finalLabel, 'gtw/revise', 'Any item (even low severity) should trigger revise');
+});
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log('\n' + '='.repeat(60));
+console.log(`Tests completed: ${passed + failed} total, ${passed} passed, ${failed} failed`);
+console.log('='.repeat(60));
+
+process.exit(failed > 0 ? 1 : 0);

--- a/test/unit-review-verdict.test.js
+++ b/test/unit-review-verdict.test.js
@@ -11,50 +11,7 @@
  */
 
 import { strict as assert } from 'assert';
-
-// ---------------------------------------------------------------------------
-// Pure verdict computation (mirrors the logic in ReviewCommand._reviewPr)
-// ---------------------------------------------------------------------------
-
-/**
- * Compute the verdict and label based on detection results.
- * This is extracted logic for testability.
- */
-function computeVerdict(duplicateResults, cleanupResults) {
-  const items = duplicateResults?.items || [];
-  const cleanups = cleanupResults?.cleanups || [];
-
-  const totalReuseIssues = items.length;
-  const totalCleanupIssues = cleanups.length;
-
-  let finalLabel = 'gtw/lgtm';
-  if (totalReuseIssues > 0 || totalCleanupIssues > 0) {
-    finalLabel = 'gtw/revise';
-  }
-
-  return {
-    finalLabel,
-    totalReuseIssues,
-    totalCleanupIssues,
-    verdictText: finalLabel === 'gtw/lgtm' ? 'APPROVED' : 'CHANGES NEEDED',
-  };
-}
-
-/**
- * Build comment icons (mirrors ReviewCommand._buildComment icon logic)
- */
-function computeCommentIcons(duplicateResults, cleanupResults) {
-  const items = duplicateResults?.items || [];
-  const cleanups = cleanupResults?.cleanups || [];
-
-  const totalReuseIssues = items.length;
-  const totalCleanupIssues = cleanups.length;
-
-  const reuseIcon = totalReuseIssues === 0 ? '☑️' : '❌';
-  const cleanupIcon = totalCleanupIssues === 0 ? '☑️' : '❌';
-
-  return { reuseIcon, cleanupIcon, totalReuseIssues, totalCleanupIssues };
-}
+import { computeReviewVerdict, computeReviewIcons } from '../commands/ReviewCommand.js';
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -85,7 +42,7 @@ test('No issues: verdict is APPROVED and label is gtw/lgtm', () => {
   const duplicateResults = { items: [], newFunctions: [] };
   const cleanupResults = { cleanups: [] };
 
-  const result = computeVerdict(duplicateResults, cleanupResults);
+  const result = computeReviewVerdict(duplicateResults, cleanupResults);
 
   assert.strictEqual(result.finalLabel, 'gtw/lgtm', 'Label should be gtw/lgtm');
   assert.strictEqual(result.verdictText, 'APPROVED', 'Verdict should be APPROVED');
@@ -97,7 +54,7 @@ test('No issues: comment icons are both ☑️', () => {
   const duplicateResults = { items: [], newFunctions: [] };
   const cleanupResults = { cleanups: [] };
 
-  const icons = computeCommentIcons(duplicateResults, cleanupResults);
+  const icons = computeReviewIcons(duplicateResults, cleanupResults);
 
   assert.strictEqual(icons.reuseIcon, '☑️', 'Reuse icon should be ☑️');
   assert.strictEqual(icons.cleanupIcon, '☑️', 'Cleanup icon should be ☑️');
@@ -107,8 +64,8 @@ test('No issues: comment icons and label are consistent', () => {
   const duplicateResults = { items: [], newFunctions: [] };
   const cleanupResults = { cleanups: [] };
 
-  const verdict = computeVerdict(duplicateResults, cleanupResults);
-  const icons = computeCommentIcons(duplicateResults, cleanupResults);
+  const verdict = computeReviewVerdict(duplicateResults, cleanupResults);
+  const icons = computeReviewIcons(duplicateResults, cleanupResults);
 
   // If icons are both ☑️, label must be gtw/lgtm
   if (icons.reuseIcon === '☑️' && icons.cleanupIcon === '☑️') {
@@ -135,7 +92,7 @@ test('Reuse issues present: verdict is CHANGES NEEDED and label is gtw/revise', 
   };
   const cleanupResults = { cleanups: [] };
 
-  const result = computeVerdict(duplicateResults, cleanupResults);
+  const result = computeReviewVerdict(duplicateResults, cleanupResults);
 
   assert.strictEqual(result.finalLabel, 'gtw/revise', 'Label should be gtw/revise');
   assert.strictEqual(result.verdictText, 'CHANGES NEEDED', 'Verdict should be CHANGES NEEDED');
@@ -156,7 +113,7 @@ test('Cleanup issues present: verdict is CHANGES NEEDED and label is gtw/revise'
     ],
   };
 
-  const result = computeVerdict(duplicateResults, cleanupResults);
+  const result = computeReviewVerdict(duplicateResults, cleanupResults);
 
   assert.strictEqual(result.finalLabel, 'gtw/revise', 'Label should be gtw/revise');
   assert.strictEqual(result.verdictText, 'CHANGES NEEDED', 'Verdict should be CHANGES NEEDED');
@@ -173,7 +130,7 @@ test('Both issues present: verdict is CHANGES NEEDED and label is gtw/revise', (
     cleanups: [{ symbol: 'x', file: 'y', severity: 'low', whyCleanup: 'z' }],
   };
 
-  const result = computeVerdict(duplicateResults, cleanupResults);
+  const result = computeReviewVerdict(duplicateResults, cleanupResults);
 
   assert.strictEqual(result.finalLabel, 'gtw/revise', 'Label should be gtw/revise');
   assert.strictEqual(result.verdictText, 'CHANGES NEEDED', 'Verdict should be CHANGES NEEDED');
@@ -189,7 +146,7 @@ test('Issues present: comment icons are both ❌', () => {
     cleanups: [{ symbol: 'x', file: 'y', severity: 'low', whyCleanup: 'z' }],
   };
 
-  const icons = computeCommentIcons(duplicateResults, cleanupResults);
+  const icons = computeReviewIcons(duplicateResults, cleanupResults);
 
   assert.strictEqual(icons.reuseIcon, '❌', 'Reuse icon should be ❌');
   assert.strictEqual(icons.cleanupIcon, '❌', 'Cleanup icon should be ❌');
@@ -201,8 +158,8 @@ test('Issues present: comment icons and label are consistent', () => {
   };
   const cleanupResults = { cleanups: [] };
 
-  const verdict = computeVerdict(duplicateResults, cleanupResults);
-  const icons = computeCommentIcons(duplicateResults, cleanupResults);
+  const verdict = computeReviewVerdict(duplicateResults, cleanupResults);
+  const icons = computeReviewIcons(duplicateResults, cleanupResults);
 
   // If reuse icon is ❌, label must be gtw/revise
   if (icons.reuseIcon === '❌') {
@@ -220,7 +177,7 @@ test('detectReuse errors with zero findings: verdict is APPROVED (not CHANGES NE
   const duplicateResults = { error: 'API timeout', items: [], newFunctions: [] };
   const cleanupResults = { cleanups: [] };
 
-  const result = computeVerdict(duplicateResults, cleanupResults);
+  const result = computeReviewVerdict(duplicateResults, cleanupResults);
 
   // BUG: Old code would set gtw/revise because duplicateResults.error was truthy
   // FIX: Should be gtw/lgtm because items.length === 0
@@ -233,7 +190,7 @@ test('detectUnnecessaryCleanup errors with zero findings: verdict is APPROVED', 
   const duplicateResults = { items: [], newFunctions: [] };
   const cleanupResults = { error: 'Network error', cleanups: [], llmCandidates: [], skipped: [] };
 
-  const result = computeVerdict(duplicateResults, cleanupResults);
+  const result = computeReviewVerdict(duplicateResults, cleanupResults);
 
   assert.strictEqual(result.finalLabel, 'gtw/lgtm', 'Label should be gtw/lgtm even with error');
   assert.strictEqual(result.verdictText, 'APPROVED', 'Verdict should be APPROVED even with error');
@@ -244,7 +201,7 @@ test('Both detection functions error with zero findings: verdict is APPROVED', (
   const duplicateResults = { error: 'timeout', items: [], newFunctions: [] };
   const cleanupResults = { error: 'network', cleanups: [], llmCandidates: [], skipped: [] };
 
-  const result = computeVerdict(duplicateResults, cleanupResults);
+  const result = computeReviewVerdict(duplicateResults, cleanupResults);
 
   assert.strictEqual(result.finalLabel, 'gtw/lgtm', 'Label should be gtw/lgtm when both error with zero findings');
   assert.strictEqual(result.verdictText, 'APPROVED', 'Verdict should be APPROVED');
@@ -254,8 +211,8 @@ test('Error with zero findings: comment icons remain ☑️ (consistent with lab
   const duplicateResults = { error: 'timeout', items: [], newFunctions: [] };
   const cleanupResults = { error: 'network', cleanups: [] };
 
-  const verdict = computeVerdict(duplicateResults, cleanupResults);
-  const icons = computeCommentIcons(duplicateResults, cleanupResults);
+  const verdict = computeReviewVerdict(duplicateResults, cleanupResults);
+  const icons = computeReviewIcons(duplicateResults, cleanupResults);
 
   // Both icons should be ☑️ because items.length and cleanups.length are 0
   assert.strictEqual(icons.reuseIcon, '☑️', 'Reuse icon should be ☑️');
@@ -273,7 +230,7 @@ test('Error with actual findings also present: verdict is CHANGES NEEDED', () =>
   };
   const cleanupResults = { cleanups: [] };
 
-  const result = computeVerdict(duplicateResults, cleanupResults);
+  const result = computeReviewVerdict(duplicateResults, cleanupResults);
 
   // Error + findings = gtw/revise (correctly based on findings)
   assert.strictEqual(result.finalLabel, 'gtw/revise', 'Label should be gtw/revise when findings exist');
@@ -289,7 +246,7 @@ test('Null/undefined items treated as empty array', () => {
   const duplicateResults = { items: null };
   const cleanupResults = { cleanups: undefined };
 
-  const result = computeVerdict(duplicateResults, cleanupResults);
+  const result = computeReviewVerdict(duplicateResults, cleanupResults);
 
   assert.strictEqual(result.finalLabel, 'gtw/lgtm', 'Null/undefined items should be treated as empty');
   assert.strictEqual(result.totalReuseIssues, 0, 'Null items should count as 0');
@@ -297,8 +254,8 @@ test('Null/undefined items treated as empty array', () => {
 });
 
 test('Empty items arrays are distinct from missing items property', () => {
-  const results1 = computeVerdict({}, {});
-  const results2 = computeVerdict({ items: [] }, { cleanups: [] });
+  const results1 = computeReviewVerdict({}, {});
+  const results2 = computeReviewVerdict({ items: [] }, { cleanups: [] });
 
   // Both should be APPROVED
   assert.strictEqual(results1.finalLabel, 'gtw/lgtm');
@@ -313,7 +270,7 @@ test('Low severity items still trigger gtw/revise (all items count)', () => {
   };
   const cleanupResults = { cleanups: [] };
 
-  const result = computeVerdict(duplicateResults, cleanupResults);
+  const result = computeReviewVerdict(duplicateResults, cleanupResults);
 
   // The issue says verdict is based on totals, so any item should trigger revise
   assert.strictEqual(result.finalLabel, 'gtw/revise', 'Any item (even low severity) should trigger revise');


### PR DESCRIPTION
fix(gtw): align review verdict and PR label with published comment

This PR addresses review verdict alignment and PR label consistency.

## Summary by Sourcery

Align GTW review verdict/PR label logic with the review comment output and simplify the review comment format.

Bug Fixes:
- Base the GTW review verdict and PR label solely on the presence of reuse and cleanup findings, ignoring error flags when there are zero findings to keep them consistent with the published comment icons.

Enhancements:
- Redesign the review comment body to use a concise GTW-branded header, status icons, and severity-grouped tables for reuse and cleanup findings, removing PR metadata, verbose text, and code blocks from the comment.
- Sanitize table cell content in review comments to avoid markdown formatting issues.
- Ensure the bot updates existing review comments based on the new GTW Code Review heading.

Tests:
- Add focused unit tests for the new _buildComment output format to validate title, status icons, content exclusions, and table structure.
- Add standalone unit tests for verdict/label computation and comment icon logic to guarantee consistency between PR labels and published review comments in various success, error, and edge-case scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verdict/label logic now uses actual finding counts (not error flags) and summary shows total reuse and cleanup issue counts.
  * Summary details continue to surface critical/high items when present, with conditional sections adjusted accordingly.
  * Comment icons/counts are computed consistently from totals.

* **Tests**
  * Added unit tests covering verdicts, labels, icons, and error-edge cases for reuse/cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->