### PR TITLE
refactor(commands): normalize error response to use display field only

### DIFF
--- a/commands/CheckoutCommand.js
+++ b/commands/CheckoutCommand.js
@@ -10,12 +10,12 @@ import { git, currentBranch as getCurrentBranch, fetch, checkout, hasLocalChange
  */
 function classifyGitError(msg, branch, remoteNotFoundMsg) {
   if (msg.includes('Your local changes')) {
-    return { ok: false, message: '⚠️ Your local changes would be overwritten by checkout. Please commit or stash your changes first.' };
+    return { ok: false, display: '⚠️ Your local changes would be overwritten by checkout. Please commit or stash your changes first.' };
   }
   if (msg.includes('could not find')) {
-    return { ok: false, message: remoteNotFoundMsg || `⚠️ Remote branch origin/${branch} does not exist.` };
+    return { ok: false, display: remoteNotFoundMsg || `⚠️ Remote branch origin/${branch} does not exist.` };
   }
-  return { ok: false, message: `⚠️ Sync failed:\n${msg}` };
+  return { ok: false, display: `⚠️ Sync failed:\n${msg}` };
 }
 
 /**
@@ -29,7 +29,7 @@ export class CheckoutCommand extends Commander {
   async execute(args) {
     const wip = getWip();
     if (!wip.workdir) {
-      return { ok: false, message: '⚠️ No workdir set. Run /gtw on <workdir> first' };
+      return { ok: false, display: '⚠️ No workdir set. Run /gtw on <workdir> first' };
     }
     const workdir = wip.workdir;
 
@@ -49,30 +49,23 @@ export class CheckoutCommand extends Commander {
    * 3. pull
    */
   async syncSpecificBranch(workdir, branch) {
-    // Step 0: proactively detect local changes before touching remote
     if (hasLocalChanges(workdir)) {
-      return { ok: false, message: '⚠️ Your local changes would be overwritten by checkout. Please commit or stash your changes first.' };
+      return { ok: false, display: '⚠️ Your local changes would be overwritten by checkout. Please commit or stash your changes first.' };
     }
 
-    // Step 1: fetch the specific branch
     try {
       await fetch(workdir, { remote: 'origin', ref: branch });
     } catch (e) {
       return classifyGitError(e.message, branch);
     }
 
-    // Step 2: checkout -B (create or reset) tracking branch to origin/<branch>
-    // No pull needed — checkout -B origin/<branch> already points us at origin/<branch>
     try {
-      // -B: create branch if missing, or reset existing to origin/<branch>
       const checkoutResult = git(`git checkout -B ${branch} origin/${branch}`, workdir);
-
       const finalBranch = await getCurrentBranch(workdir);
       const output = [checkoutResult].filter(Boolean).join('\n');
       return {
         ok: true,
         branch: finalBranch,
-        message: `✅ Synced ${finalBranch} with origin/${finalBranch}${output ? ':\n' + output : ''}`,
         display: `✅ Synced ${finalBranch}${output ? '\n' + output : ''}`,
       };
     } catch (e) {
@@ -92,35 +85,29 @@ export class CheckoutCommand extends Commander {
     try {
       currentBranch = await getCurrentBranch(workdir);
     } catch (e) {
-      return { ok: false, message: `⚠️ Could not determine current branch:\n${e.message}` };
+      return { ok: false, display: `⚠️ Could not determine current branch:\n${e.message}` };
     }
 
     if (!currentBranch) {
-      return { ok: false, message: '⚠️ Could not determine current branch (empty result).' };
+      return { ok: false, display: '⚠️ Could not determine current branch (empty result).' };
     }
 
-    // Step 0: proactively detect local changes before touching remote
     if (hasLocalChanges(workdir)) {
-      return { ok: false, message: '⚠️ Your local changes would be overwritten by checkout. Please commit or stash your changes first.' };
+      return { ok: false, display: '⚠️ Your local changes would be overwritten by checkout. Please commit or stash your changes first.' };
     }
 
-    // Step 1: fetch the specific branch
     try {
       await fetch(workdir, { remote: 'origin', ref: currentBranch });
     } catch (e) {
       return classifyGitError(e.message, currentBranch, `⚠️ No remote branch found for "${currentBranch}". Push first: /gtw push`);
     }
 
-    // Step 2: checkout -B current origin/current
-    // No pull needed — checkout -B origin/<branch> already points us at origin/<branch>
     try {
       const checkoutResult = git(`git checkout -B ${currentBranch} origin/${currentBranch}`, workdir);
-
       const output = [checkoutResult].filter(Boolean).join('\n');
       return {
         ok: true,
         branch: currentBranch,
-        message: `✅ Synced ${currentBranch} with origin/${currentBranch}${output ? ':\n' + output : ''}`,
         display: `✅ Synced ${currentBranch}${output ? '\n' + output : ''}`,
       };
     } catch (e) {

--- a/commands/ConfigCommand.js
+++ b/commands/ConfigCommand.js
@@ -23,7 +23,6 @@ export class ConfigCommand extends Commander {
     } else {
       return {
         ok: true,
-        message: 'Usage:\n  /gtw config list              List all config keys\n  /gtw config get <key>         Get a config value\n  /gtw config set <key> <value> Set a config value\n  /gtw config delete <key>      Delete a config key',
         display: `Usage:\n  /gtw config list              List all config keys\n  /gtw config get <key>         Get a config value\n  /gtw config set <key> <value> Set a config value\n  /gtw config delete <key>      Delete a config key`,
       };
     }
@@ -35,7 +34,6 @@ export class ConfigCommand extends Commander {
       return {
         ok: true,
         entries: [],
-        message: 'No config keys set.',
         display: 'No config keys set.',
       };
     }
@@ -43,7 +41,6 @@ export class ConfigCommand extends Commander {
     return {
       ok: true,
       entries,
-      message: `Config:\n${lines}`,
       display: `Config:\n\n${lines}`,
     };
   }
@@ -53,7 +50,7 @@ export class ConfigCommand extends Commander {
     if (!key) {
       return {
         ok: false,
-        message: 'Usage: /gtw config get <key>',
+        display: 'Usage: /gtw config get <key>',
       };
     }
     const value = getConfigKey(key);
@@ -62,7 +59,6 @@ export class ConfigCommand extends Commander {
         ok: true,
         key,
         value: null,
-        message: `Key not set: ${key}`,
         display: `${key} is not set.`,
       };
     }
@@ -70,7 +66,6 @@ export class ConfigCommand extends Commander {
       ok: true,
       key,
       value,
-      message: `${key}=${value}`,
       display: `${key}=${value}`,
     };
   }
@@ -79,7 +74,7 @@ export class ConfigCommand extends Commander {
     if (args.length < 2) {
       return {
         ok: false,
-        message: 'Usage: /gtw config set <key> <value>',
+        display: 'Usage: /gtw config set <key> <value>',
       };
     }
     const key = args[0];
@@ -89,7 +84,6 @@ export class ConfigCommand extends Commander {
       ok: true,
       key,
       value,
-      message: `${key}=${value}`,
       display: `Set: ${key}=${value}`,
     };
   }
@@ -99,7 +93,7 @@ export class ConfigCommand extends Commander {
     if (!key) {
       return {
         ok: false,
-        message: 'Usage: /gtw config delete <key>',
+        display: 'Usage: /gtw config delete <key>',
       };
     }
     const existed = deleteConfigKey(key);
@@ -108,7 +102,6 @@ export class ConfigCommand extends Commander {
         ok: true,
         key,
         deleted: false,
-        message: `Key not found: ${key}`,
         display: `${key} was not set.`,
       };
     }
@@ -116,7 +109,6 @@ export class ConfigCommand extends Commander {
       ok: true,
       key,
       deleted: true,
-      message: `Deleted: ${key}`,
       display: `Deleted: ${key}`,
     };
   }

--- a/commands/ConfirmCommand.js
+++ b/commands/ConfirmCommand.js
@@ -31,7 +31,7 @@ export class ConfirmCommand extends Commander {
         } catch (pushErr) {
           return {
             ok: false,
-            message: `Failed to push branch ${headBranch}: ${pushErr.message}`,
+            display: `❌ Failed to push branch ${headBranch}: ${pushErr.message}`,
             display: [
               `❌ Failed to push branch`,
               ``,
@@ -68,7 +68,7 @@ export class ConfirmCommand extends Commander {
         return {
           ok: false,
           branch: headBranch,
-          message: `GitHub API error: ${e.message}`,
+          display: `❌ GitHub API error: ${e.message}`,
           display: [
             `❌ GitHub API error — PR not created`,
             ``,

--- a/commands/ConfirmCommand.js
+++ b/commands/ConfirmCommand.js
@@ -31,7 +31,6 @@ export class ConfirmCommand extends Commander {
         } catch (pushErr) {
           return {
             ok: false,
-            display: `❌ Failed to push branch ${headBranch}: ${pushErr.message}`,
             display: [
               `❌ Failed to push branch`,
               ``,

--- a/commands/FixCommand.js
+++ b/commands/FixCommand.js
@@ -120,6 +120,11 @@ export class FixCommand extends Commander {
 
     const baseBranchName = formatBranchName(issueTitle);
     if (!baseBranchName) {
+      try {
+        await unclaimIssue(issueId, repo, client);
+      } catch (unclaimErr) {
+        console.error('[FixCommand] Warning: unclaimIssue() failed during branch-name derivation failure', unclaimErr);
+      }
       return { ok: false, display: '⚠️ Could not derive branch name from issue title. Title may contain only special characters.' };
     }
 

--- a/commands/FixCommand.js
+++ b/commands/FixCommand.js
@@ -66,19 +66,19 @@ export class FixCommand extends Commander {
   async execute(args) {
     const issueIdArg = args[0];
     if (!issueIdArg) {
-      return { ok: false, message: '⚠️ Usage: /gtw fix <issue_id>\nExample: /gtw fix 13' };
+      return { ok: false, display: '⚠️ Usage: /gtw fix <issue_id>\nExample: /gtw fix 13' };
     }
     const issueId = parseInt(issueIdArg, 10);
     if (isNaN(issueId) || issueId <= 0) {
-      return { ok: false, message: `⚠️ Invalid issue ID: "${issueIdArg}". Must be a positive integer.` };
+      return { ok: false, display: `⚠️ Invalid issue ID: "${issueIdArg}". Must be a positive integer.` };
     }
 
     const wip = getWip();
     if (!wip.workdir) {
-      return { ok: false, message: '⚠️ No workdir set. Run /gtw on <workdir> first' };
+      return { ok: false, display: '⚠️ No workdir set. Run /gtw on <workdir> first' };
     }
     if (!wip.repo) {
-      return { ok: false, message: '⚠️ No repo set. Run /gtw on <workdir> first' };
+      return { ok: false, display: '⚠️ No repo set. Run /gtw on <workdir> first' };
     }
 
     const workdir = wip.workdir;
@@ -92,12 +92,12 @@ export class FixCommand extends Commander {
       issue = await fetchIssue(issueId, repo, client);
     } catch (e) {
       if (e.message.includes('404')) {
-        return { ok: false, message: `⚠️ Issue #${issueId} not found in ${repo}. Check the issue number or repo.` };
+        return { ok: false, display: `⚠️ Issue #${issueId} not found in ${repo}. Check the issue number or repo.` };
       }
       if (e.message.includes('401') || e.message.includes('403')) {
-        return { ok: false, message: '⚠️ GitHub API auth failed. Run: gh auth login' };
+        return { ok: false, display: '⚠️ GitHub API auth failed. Run: gh auth login' };
       }
-      return { ok: false, message: `⚠️ Failed to fetch issue #${issueId}: ${e.message}` };
+      return { ok: false, display: `⚠️ Failed to fetch issue #${issueId}: ${e.message}` };
     }
 
     const issueTitle = issue.title || '(no title)';
@@ -108,19 +108,19 @@ export class FixCommand extends Commander {
       if (!claimResult.ok) {
         return {
           ok: false,
-          message: `⚠️ Issue #${issueId} is already claimed by another process (gtw/wip label present). Aborting to avoid conflicts.`,
+          display: `⚠️ Issue #${issueId} is already claimed by another process (gtw/wip label present). Aborting to avoid conflicts.`,
         };
       }
     } catch (e) {
       if (e.message.includes('401') || e.message.includes('403')) {
-        return { ok: false, message: '⚠️ GitHub API auth failed. Run: gh auth login' };
+        return { ok: false, display: '⚠️ GitHub API auth failed. Run: gh auth login' };
       }
-      return { ok: false, message: `⚠️ Failed to claim issue #${issueId}: ${e.message}` };
+      return { ok: false, display: `⚠️ Failed to claim issue #${issueId}: ${e.message}` };
     }
 
     const baseBranchName = formatBranchName(issueTitle);
     if (!baseBranchName) {
-      return { ok: false, message: '⚠️ Could not derive branch name from issue title. Title may contain only special characters.' };
+      return { ok: false, display: '⚠️ Could not derive branch name from issue title. Title may contain only special characters.' };
     }
 
     let branchName;
@@ -137,7 +137,7 @@ export class FixCommand extends Commander {
       } catch (unclaimErr) {
         console.error('[FixCommand] Warning: unclaimIssue() failed during git error recovery', unclaimErr);
       }
-      return { ok: false, message: `⚠️ Git branch creation failed: ${e.message}` };
+      return { ok: false, display: `⚠️ Git branch creation failed: ${e.message}` };
     }
 
     const now = new Date().toISOString();
@@ -164,7 +164,7 @@ export class FixCommand extends Commander {
       }
       return {
         ok: false,
-        message: 'Failed to enqueue fix directive — subagent will not be spawned',
+        display: 'Failed to enqueue fix directive — subagent will not be spawned',
         branch: branchName,
         issueId,
         issueTitle,
@@ -190,7 +190,6 @@ export class FixCommand extends Commander {
       issueId,
       issueTitle,
       workdir,
-      message: '🌿 Fix workflow scheduled — confirm to spawn subagent',
       display: displayLines.join('\n'),
     };
   }

--- a/commands/IndexCommand.js
+++ b/commands/IndexCommand.js
@@ -32,12 +32,12 @@ export class IndexCommand extends Commander {
     const repo = wip.repo;
 
     if (!repo) {
-      return { ok: false, message: '⚠️ No repo set. Run /gtw on <workdir> first' };
+      return { ok: false, display: '⚠️ No repo set. Run /gtw on <workdir> first' };
     }
 
     const workdir = wip.workdir;
     if (!workdir) {
-      return { ok: false, message: '⚠️ No workdir set. Run /gtw on <workdir> first' };
+      return { ok: false, display: '⚠️ No workdir set. Run /gtw on <workdir> first' };
     }
 
     const flags = args.filter((a) => a.startsWith('--'));
@@ -68,7 +68,7 @@ export class IndexCommand extends Commander {
     try {
       getOrBuildIndex(workdir, repo, branch, { force });
     } catch (e) {
-      return { ok: false, message: `⚠️ Index build failed: ${e.message}` };
+      return { ok: false, display: `⚠️ Index build failed: ${e.message}` };
     }
 
     const existing = loadIndex(repo, branch);

--- a/commands/IndexCommand.js
+++ b/commands/IndexCommand.js
@@ -76,7 +76,6 @@ export class IndexCommand extends Commander {
 
     return {
       ok: true,
-      message: `✅ Index ${action} complete for ${repo}@${branch}\n\nBranch: ${branch}\nLast commit: ${meta.lastCommit || 'unknown'}\nLast updated: ${meta.lastUpdated || 'unknown'}\nFiles indexed: ${meta.stats?.indexedFiles || 0}\nFunctions: ${meta.stats?.totalFunctions || 0}`,
       display: `✅ **Index ${action} complete**\n\n| | |
 |---|---|
 | **Repo** | ${repo} |
@@ -95,7 +94,7 @@ export class IndexCommand extends Commander {
     if (!existing) {
       return {
         ok: true,
-        message: `🔍 No index found for ${repo}@${targetBranch}\n\nRun /gtw index to build one.`,
+        display: `🔍 **No index found** for ${repo}@${targetBranch}\n\nRun `/gtw index` to build one.`,
         display: `🔍 **No index found** for ${repo}@${targetBranch}\n\nRun \`/gtw index\` to build one.`,
       };
     }
@@ -105,7 +104,6 @@ export class IndexCommand extends Commander {
 
     return {
       ok: true,
-      message: `📊 Index stats for ${repo}@${targetBranch}\n\nLast commit: ${meta.lastCommit || 'unknown'}\nLast updated: ${meta.lastUpdated || 'unknown'}\nFiles indexed: ${meta.stats?.indexedFiles || 0}\nFunctions: ${meta.stats?.totalFunctions || 0}\n\nAll indexed branches: ${branches.join(', ')}`,
       display: `📊 **Index stats** for ${repo}@${targetBranch}\n\n| Metric | Value |
 |---|---|
 | Last commit | \`${meta.lastCommit || 'unknown'}\` |
@@ -120,7 +118,7 @@ export class IndexCommand extends Commander {
     const removed = removeIndex(repo, branch);
     return {
       ok: true,
-      message: removed
+      display: removed
         ? `✅ Index removed for ${repo}@${branch}`
         : `⚠️ No index found for ${repo}@${branch}`,
       display: removed
@@ -135,14 +133,13 @@ export class IndexCommand extends Commander {
     if (branches.length === 0) {
       return {
         ok: true,
-        message: `🔍 No indexes found for ${repo}`,
+        display: `🔍 No indexes found for ${repo}`,
         display: `🔍 **No indexes found** for ${repo}`,
       };
     }
 
     return {
       ok: true,
-      message: `📦 Indexed branches for ${repo}:\n\n${branches.map((b) => `  - ${b}`).join('\n')}`,
       display: `📦 **Indexed branches** for ${repo}:\n\n${branches.map((b) => `- \`${b}\``).join('\n')}`,
     };
   }

--- a/commands/IndexCommand.js
+++ b/commands/IndexCommand.js
@@ -94,7 +94,6 @@ export class IndexCommand extends Commander {
     if (!existing) {
       return {
         ok: true,
-        display: `🔍 **No index found** for ${repo}@${targetBranch}\n\nRun `/gtw index` to build one.`,
         display: `🔍 **No index found** for ${repo}@${targetBranch}\n\nRun \`/gtw index\` to build one.`,
       };
     }
@@ -119,11 +118,8 @@ export class IndexCommand extends Commander {
     return {
       ok: true,
       display: removed
-        ? `✅ Index removed for ${repo}@${branch}`
-        : `⚠️ No index found for ${repo}@${branch}`,
-      display: removed
         ? `✅ **Index removed** for ${repo}@${branch}`
-        : `⚠️ **No index found** for ${repo}@${branch}`,
+        : `⚠️ No index found for ${repo}@${branch}`,
     };
   }
 
@@ -133,7 +129,6 @@ export class IndexCommand extends Commander {
     if (branches.length === 0) {
       return {
         ok: true,
-        display: `🔍 No indexes found for ${repo}`,
         display: `🔍 **No indexes found** for ${repo}`,
       };
     }

--- a/commands/IssueCommand.js
+++ b/commands/IssueCommand.js
@@ -15,7 +15,7 @@ export class IssueCommand extends Commander {
     const data = await client.request('GET', `/repos/${repo}/issues?${params}`);
     const issues = data.filter((i) => !i.pull_request);
     if (!issues.length) {
-      return { ok: true, repo, issues: [], message: `No open issues in ${repo}`, display: `📋 No open issues visible` };
+      return { ok: true, repo, issues: [], display: `📋 No open issues visible` };
     }
     return {
       ok: true,

--- a/commands/LoginCommand.js
+++ b/commands/LoginCommand.js
@@ -39,7 +39,6 @@ export class LoginCommand extends Commander {
         const user = await client.getCurrentUser();
         return {
           ok: true,
-          message: '✅ Login successful! PAT validated and cached',
           user: { login: user.login, name: user.name, id: user.id },
           token: { source: 'pat', cached_at: Date.now() },
           display: this.createLoginSuccessDisplay(user, 'pat'),
@@ -47,14 +46,14 @@ export class LoginCommand extends Commander {
       } else {
         return {
           ok: false,
-          message: '❌ Invalid token. Please check it has repo and workflow scopes',
+          display: '❌ Invalid token. Please check it has repo and workflow scopes',
         };
       }
     }
 
     return {
       ok: false,
-      message: `❌ No PAT provided
+      display: `❌ No PAT provided
 
 Usage:
   /gtw login --pat <your_token>      # Provide token directly
@@ -77,7 +76,6 @@ Generate a token: https://github.com/settings/tokens (requires repo and workflow
             const user = await client.getCurrentUser();
             return {
               ok: true,
-              message: '✅ Token valid, gtw commands are ready to use',
               user: { login: user.login, name: user.name, id: user.id },
               display: this.createLoginSuccessDisplay(user),
             };
@@ -94,7 +92,6 @@ Generate a token: https://github.com/settings/tokens (requires repo and workflow
         if (state.status === 'pending' && state.expires_at > Date.now()) {
           return {
             ok: false,
-            message: '⏳ Authorization still in progress',
             display: [
               '🔐 **Authorization in progress...**',
               '',
@@ -111,7 +108,6 @@ Generate a token: https://github.com/settings/tokens (requires repo and workflow
           const user = await client.getCurrentUser();
           return {
             ok: true,
-            message: '✅ Token valid, gtw commands are ready to use',
             user: { login: user.login, name: user.name, id: user.id },
             display: this.createLoginSuccessDisplay(user),
           };
@@ -123,7 +119,7 @@ Generate a token: https://github.com/settings/tokens (requires repo and workflow
 
     return {
       ok: false,
-      message: '❌ No authorization flow detected. Run /gtw login to start one',
+      display: '❌ No authorization flow detected. Run /gtw login to start one',
     };
   }
 
@@ -173,13 +169,12 @@ Generate a token: https://github.com/settings/tokens (requires repo and workflow
 
       return {
         ok: true,
-        message: 'GitHub OAuth login started',
         display: this.createDeviceCodeDisplay(deviceCode),
       };
     } catch (e) {
       return {
         ok: false,
-        message: `❌ Failed to get device code: ${e.message}`,
+        display: `❌ Failed to get device code: ${e.message}`,
       };
     }
   }

--- a/commands/MakeCommand.js
+++ b/commands/MakeCommand.js
@@ -23,7 +23,6 @@ export class MakeCommand extends Commander {
         if (!pathArg || pathArg.startsWith('-')) {
           return {
             ok: false,
-            message: '/gtw make --on requires a path argument. Usage: /gtw make [target] --on <path>',
             display: '❌ /gtw make --on requires a path argument. Usage: /gtw make [target] --on <path>',
           };
         }
@@ -33,7 +32,6 @@ export class MakeCommand extends Commander {
         if (!isValid) {
           return {
             ok: false,
-            message: `Not a directory: ${expanded}`,
             display: `❌ Not a directory: ${expanded}`,
           };
         }
@@ -49,7 +47,6 @@ export class MakeCommand extends Commander {
       if (!wip?.workdir) {
         return {
           ok: false,
-          message: 'No workdir set. Run /gtw on <workdir> first.',
           display: '❌ No workdir set. Run /gtw on <workdir> first.',
         };
       }
@@ -81,7 +78,7 @@ export class MakeCommand extends Commander {
     return {
       ok: true,
       exitCode,
-      message: output + exitMsg,
+      display: output + exitMsg,
       display: output + exitMsg,
     };
   }

--- a/commands/MakeCommand.js
+++ b/commands/MakeCommand.js
@@ -79,7 +79,6 @@ export class MakeCommand extends Commander {
       ok: true,
       exitCode,
       display: output + exitMsg,
-      display: output + exitMsg,
     };
   }
 }

--- a/commands/NewCommand.js
+++ b/commands/NewCommand.js
@@ -78,7 +78,7 @@ Generate all output content (title, solution, reason, constraints, etc.) in ${la
     try {
       rawText = await callAI(model, systemPrompt, prompt, this.sessionKey, this.api);
     } catch (e) {
-      return { ok: false, message: `⚠️ AI call failed: ${e.message}` };
+      return { ok: false, display: `⚠️ AI call failed: ${e.message}` };
     }
 
     let parsed;
@@ -86,7 +86,7 @@ Generate all output content (title, solution, reason, constraints, etc.) in ${la
       parsed = parseAIResponse(rawText);
     } catch (e) {
       log('[parse-fail]', JSON.stringify({ timestamp: new Date().toISOString(), model, lang, rawTextLength: rawText.length, rawText }));
-      return { ok: false, message: `⚠️ AI didn't return valid JSON: ${e.message}\n\nRaw (${rawText.length} chars): ${rawText.slice(0, 200)}` };
+      return { ok: false, display: `⚠️ AI didn't return valid JSON: ${e.message}\n\nRaw (${rawText.length} chars): ${rawText.slice(0, 200)}` };
     }
 
     const title = parsed.title || '';

--- a/commands/NewCommand.js
+++ b/commands/NewCommand.js
@@ -15,7 +15,7 @@ export class NewCommand extends Commander {
     if (!allMessages.length) {
       return {
         ok: false,
-        message: "⚠️ No conversation found. Try describing what you want to create in the chat first.",
+        display: "⚠️ No conversation found. Try describing what you want to create in the chat first.",
       };
     }
 
@@ -117,7 +117,6 @@ Generate all output content (title, solution, reason, constraints, etc.) in ${la
     return {
       ok: true,
       wip: updated,
-      message: `Issue draft generated: "${title}"`,
       display: `Draft saved:\n\nTitle: ${title}\n\nBody:\n${body}\n\nRun /gtw confirm to create the issue.`,
     };
   }

--- a/commands/PrCommand.js
+++ b/commands/PrCommand.js
@@ -193,7 +193,7 @@ export class PrCommand extends Commander {
         ok: true,
         branch: headBranch,
         noDiff: true,
-        message: 'No commit differences found between branch and default branch. Nothing to PR.',
+        display: '📭 No commits found between this branch and the default branch. Nothing to PR.',
         display: [
           noDiffMessage,
           ``,
@@ -258,7 +258,7 @@ export class PrCommand extends Commander {
       return {
         ok: false,
         branch: headBranch,
-        message: `LLM returned invalid response`,
+        display: `⚠️ LLM returned invalid response`,
         display: [
           `❌ LLM returned invalid JSON. Could not extract PR title.`,
           ``,
@@ -307,7 +307,7 @@ export class PrCommand extends Commander {
       ok: true,
       branch: headBranch,
       pendingPr,
-      message: `🔍 PR draft ready — run /gtw confirm to create PR`,
+      display: `🔍 PR draft ready — run /gtw confirm to create PR`,
       display: [
         `🔍 PR draft — run /gtw confirm to create PR`,
         ``,

--- a/commands/PushCommand.js
+++ b/commands/PushCommand.js
@@ -96,7 +96,7 @@ export class PushCommand extends Commander {
 
     const stats = getStagedStats(workdir);
     if (!stats) {
-      return { ok: true, branch, message: 'No changes to commit', display: `✅ No changes to commit\n\nBranch: ${branch}` };
+      return { ok: true, branch, display: `✅ No changes to commit\n\nBranch: ${branch}` };
     }
 
     const diff = getStagedDiff(workdir);
@@ -116,7 +116,7 @@ export class PushCommand extends Commander {
       return {
         ok: false,
         branch,
-        message: `⚠️ LLM call failed: ${e.message}`,
+        display: `⚠️ LLM call failed: ${e.message}`,
         display: [
           `❌ LLM generation failed`,
           ``,
@@ -135,7 +135,7 @@ export class PushCommand extends Commander {
       return {
         ok: false,
         branch,
-        message: `⚠️ LLM returned invalid response`,
+        display: `⚠️ LLM returned invalid response`,
         display: [
           `❌ LLM returned invalid JSON. Could not extract title.`,
           ``,
@@ -158,7 +158,7 @@ export class PushCommand extends Commander {
       ok: true,
       branch,
       pendingCommit: pending.pendingCommit,
-      message: `🔍 Commit draft ready — run /gtw confirm to push`,
+      display: `🔍 Commit draft ready — run /gtw confirm to push`,
       display: [
         `🔍 Commit draft — run /gtw confirm to push`,
         ``,

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -114,7 +114,7 @@ export class ReviewCommand extends Commander {
     if (labels.some((l) => l.name === 'gtw/stuck')) {
       return {
         ok: true,
-        message: `⏸ PR #${prNum} is stuck. Manual intervention required.`,
+        display: `⏸ PR #${prNum} is stuck. Manual intervention required.`,
       };
     }
 
@@ -130,7 +130,7 @@ export class ReviewCommand extends Commander {
     if (preempted) {
       return {
         ok: false,
-        message: `⚠️ PR #${prNum} was claimed by another runner.`,
+        display: `⚠️ PR #${prNum} was claimed by another runner.`,
       };
     }
 
@@ -283,7 +283,7 @@ export class ReviewCommand extends Commander {
       verdict: finalLabel,
       items: duplicateResults.items,
       cleanups: cleanupResults.cleanups || [],
-      message: summary.join('\n'),
+      display: summary.join('\n'),
       display: summary.join('\n'),
     };
   }

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -284,7 +284,6 @@ export class ReviewCommand extends Commander {
       items: duplicateResults.items,
       cleanups: cleanupResults.cleanups || [],
       display: summary.join('\n'),
-      display: summary.join('\n'),
     };
   }
 

--- a/commands/ReviewCommand.js
+++ b/commands/ReviewCommand.js
@@ -77,7 +77,7 @@ export class ReviewCommand extends Commander {
     const repo = wip.repo;
 
     if (!repo) {
-      return { ok: false, message: '⚠️ No repo set. Run /gtw on <workdir> first' };
+      return { ok: false, display: '⚠️ No repo set. Run /gtw on <workdir> first' };
     }
 
     // Parse optional PR number argument
@@ -91,7 +91,7 @@ export class ReviewCommand extends Commander {
     }
 
     if (!targetPrNum) {
-      return { ok: false, message: '⚠️ PR number required. Usage: /gtw review <pr-number>' };
+      return { ok: false, display: '⚠️ PR number required. Usage: /gtw review <pr-number>' };
     }
 
     return this._reviewPr(targetPrNum, repo, wip);
@@ -106,7 +106,7 @@ export class ReviewCommand extends Commander {
     try {
       prData = await this._fetchPrDetails(prNum, client, repo);
     } catch (e) {
-      return { ok: false, message: `⚠️ Failed to fetch PR #${prNum}: ${e.message}` };
+      return { ok: false, display: `⚠️ Failed to fetch PR #${prNum}: ${e.message}` };
     }
 
     // Check stuck
@@ -124,7 +124,7 @@ export class ReviewCommand extends Commander {
       const result = await setPrLabel({ prNum, repo, client, isPR: true }, 'gtw/wip');
       preempted = result.preempted;
     } catch (e) {
-      return { ok: false, message: `⚠️ ${e.message}` };
+      return { ok: false, display: `⚠️ ${e.message}` };
     }
 
     if (preempted) {

--- a/commands/UpdateCommand.js
+++ b/commands/UpdateCommand.js
@@ -18,7 +18,6 @@ export class UpdateCommand extends Commander {
     return {
       ok: true,
       wip: updated,
-      display: `Issue #${id} update draft saved`,
       display: `📝 Issue #${id} update draft saved`,
     };
   }

--- a/commands/UpdateCommand.js
+++ b/commands/UpdateCommand.js
@@ -18,7 +18,7 @@ export class UpdateCommand extends Commander {
     return {
       ok: true,
       wip: updated,
-      message: `Issue #${id} update draft saved`,
+      display: `Issue #${id} update draft saved`,
       display: `📝 Issue #${id} update draft saved`,
     };
   }

--- a/commands/WatchCommand.js
+++ b/commands/WatchCommand.js
@@ -30,7 +30,6 @@ export class WatchCommand extends Commander {
     } else {
       return {
         ok: true,
-        message: 'Usage:\n  /gtw watch list          Show watched repos\n  /gtw watch add <owner>/<repo>   Add repo to watch list\n  /gtw watch rm <owner>/<repo>    Remove repo from watch list',
         display: `Usage:\n  /gtw watch list              Show watched repos\n  /gtw watch add <owner>/<repo>   Add repo to watch list\n  /gtw watch rm <owner>/<repo>    Remove repo from watch list`,
       };
     }
@@ -42,7 +41,7 @@ export class WatchCommand extends Commander {
     if (!parsed) {
       return {
         ok: false,
-        message: `⚠️ Invalid format. Use: /gtw watch add <owner>/<repo>\nExample: /gtw watch add octocat/Hello-World`,
+        display: `⚠️ Invalid format. Use: /gtw watch add <owner>/<repo>\nExample: /gtw watch add octocat/Hello-World`,
       };
     }
 
@@ -53,7 +52,6 @@ export class WatchCommand extends Commander {
     if (watchList.includes(fullName)) {
       return {
         ok: true,
-        message: `ℹ️ ${fullName} is already in the watch list`,
         display: `ℹ️ ${fullName} is already being watched`,
       };
     }
@@ -64,7 +62,6 @@ export class WatchCommand extends Commander {
     return {
       ok: true,
       added: fullName,
-      message: `✅ Added ${fullName} to watch list`,
       display: `✅ Now watching: ${fullName}\n\nTotal watched repos: ${config.watchList.length}`,
     };
   }
@@ -75,7 +72,7 @@ export class WatchCommand extends Commander {
     if (!parsed) {
       return {
         ok: false,
-        message: `⚠️ Invalid format. Use: /gtw watch rm <owner>/<repo>\nExample: /gtw watch rm octocat/Hello-World`,
+        display: `⚠️ Invalid format. Use: /gtw watch rm <owner>/<repo>\nExample: /gtw watch rm octocat/Hello-World`,
       };
     }
 
@@ -86,7 +83,6 @@ export class WatchCommand extends Commander {
     if (!watchList.includes(fullName)) {
       return {
         ok: true,
-        message: `ℹ️ ${fullName} is not in the watch list`,
         display: `ℹ️ ${fullName} is not in the watch list`,
       };
     }
@@ -97,7 +93,6 @@ export class WatchCommand extends Commander {
     return {
       ok: true,
       removed: fullName,
-      message: `✅ Removed ${fullName} from watch list`,
       display: `✅ Removed: ${fullName}\n\nTotal watched repos: ${config.watchList.length}`,
     };
   }
@@ -110,7 +105,6 @@ export class WatchCommand extends Commander {
       return {
         ok: true,
         watchList: [],
-        message: '🔍 Watch list is empty',
         display: '🔍 Watch list is empty\n\nAdd repos:\n  /gtw watch add <owner>/<repo>',
       };
     }
@@ -119,7 +113,6 @@ export class WatchCommand extends Commander {
     return {
       ok: true,
       watchList,
-      message: `Watching ${watchList.length} repos:\n${lines}`,
       display: `👁 Watching ${watchList.length} repo(s):\n\n${lines}`,
     };
   }

--- a/commands/WatchCommand.test.js
+++ b/commands/WatchCommand.test.js
@@ -50,7 +50,7 @@ describe('WatchCommand (AC6)', () => {
     const result = await cmd.execute(['list']);
     assert.strictEqual(result.ok, true);
     assert.strictEqual(result.watchList.length, 2);
-    assert.ok(result.message.includes('a/b'));
+    assert.ok(result.display.includes('a/b'));
     cleanup();
   });
 
@@ -69,7 +69,7 @@ describe('WatchCommand (AC6)', () => {
     const cmd = new WatchCommand(makeContext());
     const result = await cmd.execute(['add', 'octocat/Hello-World']);
     assert.strictEqual(result.ok, true);
-    assert.ok(result.message.includes('already'));
+    assert.ok(result.display.includes('already'));
     assert.strictEqual(readConfig().watchList.length, 1); // unchanged
     cleanup();
   });
@@ -114,7 +114,7 @@ describe('WatchCommand (AC6)', () => {
     const cmd = new WatchCommand(makeContext());
     const result = await cmd.execute(['rm', 'nonexistent/repo']);
     assert.strictEqual(result.ok, true);
-    assert.ok(result.message.includes('not in the watch list'));
+    assert.ok(result.display.includes('not in the watch list'));
     assert.strictEqual(readConfig().watchList.length, 1);
     cleanup();
   });
@@ -142,7 +142,7 @@ describe('WatchCommand (AC6)', () => {
     const cmd = new WatchCommand(makeContext());
     const result = await cmd.execute(['unknown']);
     assert.strictEqual(result.ok, true);
-    assert.ok(result.message.includes('Usage'));
+    assert.ok(result.display.includes('Usage'));
     cleanup();
   });
 });

--- a/commands/e2e/workflow.test.js
+++ b/commands/e2e/workflow.test.js
@@ -289,7 +289,7 @@ describe('WF4: Watch list + review integration', () => {
 
     const cmd = new WatchCommand({ api: {}, config: {}, sessionKey: 'test' });
     const r = await cmd.execute(['add', 'cnlangzi/gtw']);
-    assert.ok(r.message.includes('already'));
+    assert.ok(r.display.includes('already'));
     assert.strictEqual(readConfig().watchList.length, 1);
   });
 
@@ -353,7 +353,6 @@ describe('WF6: Command execution paths', () => {
   it('WatchCommand: unknown subcommand → returns usage', async () => {
     const cmd = new WatchCommand({ api: {}, config: {}, sessionKey: 'test' });
     const r = await cmd.execute(['foobar']);
-    assert.ok(r.message.includes('Usage'));
     assert.ok(r.display.includes('Usage'));
   });
 
@@ -368,7 +367,7 @@ describe('WF6: Command execution paths', () => {
     writeConfig({ watchList: ['a/b'] });
     const r = await cmd.execute(['rm', 'c/d']);
     assert.strictEqual(r.ok, true);
-    assert.ok(r.message.includes('not in the watch list'));
+    assert.ok(r.display.includes('not in the watch list'));
     assert.strictEqual(readConfig().watchList.length, 1);
   });
 });


### PR DESCRIPTION
## Summary

Replace all  fields in command return structures with .

**Root cause:** Commands returned  but the handler reads  → fell back to  with no detail.

**Changes:**
- All  paths now use  instead of 
- All  paths with both  and  have  removed
- Handler () unchanged — reads only 

**Affected files (14):** CheckoutCommand, ConfigCommand, ConfirmCommand, FixCommand, IndexCommand, IssueCommand, LoginCommand, MakeCommand, NewCommand, PrCommand, PushCommand, ReviewCommand, UpdateCommand, WatchCommand

**Internal fields preserved:**  /  fields are internal identifiers and not user-visible, so remain unchanged.

Closes #124