### PR TITLE
fix(ai): use resolveApiKeyForProvider for OpenClaw modelAuth

### DIFF
--- a/utils/ai.js
+++ b/utils/ai.js
@@ -173,9 +173,12 @@ export function findModelProviderConfig(model, agentId = 'main', options = null)
 /**
  * Make an AI API call using OpenClaw's model + auth configuration.
  * Auth token priority (when api.runtime.modelAuth is available):
- *   1. api.runtime.modelAuth.getApiKeyForModel() — resolves the full OpenClaw auth chain
- *   2. auth-profiles.json → profiles[<provider>:default].access  (PAT / device flow token)
- *   3. auth-profiles.json → profiles[<provider>:default].key    (api_key type)
+ *   1. api.runtime.modelAuth.resolveApiKeyForProvider() — resolves the full
+ *      OpenClaw auth chain (incl. SQLite-backed auth profiles in current
+ *      OpenClaw; the legacy JSON files at Priority 2/3 are auto-imported and
+ *      kept only as bak archives).
+ *   2. auth-profiles.json → profiles[<provider>:default].access  (PAT / device flow token) — legacy fallback
+ *   3. auth-profiles.json → profiles[<provider>:default].key    (api_key type) — legacy fallback
  *   4. models.json        → providers[<provider>].apiKey        (inline apiKey)
  * @param {string} model - Model id (with optional provider prefix)
  * @param {string} systemPrompt
@@ -245,14 +248,19 @@ async function _callAIOnce(model, systemPrompt, userPrompt, sessionKey, api, tim
   const providerModels = modelConf.providers?.[provider]?.models || [];
   let token = null;
 
-  // Priority 1: api.runtime.modelAuth (uses the full OpenClaw auth chain)
-  if (api?.runtime?.modelAuth) {
+  // Priority 1: api.runtime.modelAuth (uses the full OpenClaw auth chain).
+  // Use resolveApiKeyForProvider — getApiKeyForModel requires a Model object,
+  // not a string, so it can't be called here without reconstructing the model
+  // descriptor. resolveApiKeyForProvider only needs the provider name, which
+  // we already resolved via findModelProviderConfig.
+  if (api?.runtime?.modelAuth?.resolveApiKeyForProvider) {
     try {
-      const cfg = api.runtime.config.current();
-      const auth = await api.runtime.modelAuth.getApiKeyForModel({ model, cfg });
+      const cfg = api.runtime.config?.current?.();
+      const auth = await api.runtime.modelAuth.resolveApiKeyForProvider({ provider, cfg });
       token = auth?.apiKey || null;
+      if (token) console.log(`[gtw] modelAuth resolved ${provider} via ${auth.source} (${auth.mode})`);
     } catch (e) {
-      console.log('[gtw] modelAuth error:', e.message);
+      console.log(`[gtw] modelAuth.resolveApiKeyForProvider failed for ${provider}: ${e.message}`);
     }
   }
 


### PR DESCRIPTION
## Problem

After upgrading OpenClaw locally, `/gtw` AI calls started failing with:

```
AI call failed: API 401: {"type":"error","error":{"type":"authentication_error",
"message":"login fail: Please carry the API secret key in the 'X-Api-Key' field
of the request header"}}
```

## Root cause

Two compounding regressions in the auth-resolution chain inside `_callAIOnce`:

1. **Priority 1 was silently broken.** The Priority 1 path calls:

   ```js
   api.runtime.modelAuth.getApiKeyForModel({ model, cfg })
   ```

   The SDK signature (`plugin-sdk/types-Dk6viGJ9.d.ts:3299`) requires `model`
   to be a `Model<Api>` object, but we hand it the model **string** we already
   have (e.g. `"minimax-…"` or `"github/gpt-5-mini"`). The SDK dereferences
   `model.provider` / `model.api` from that string, gets `undefined`, throws,
   and our `try`/`catch` swallows the error.

2. **Priority 2/3 (legacy JSON fallback) stopped firing on current OpenClaw.**
   New OpenClaw versions migrate `auth-state.json` and `auth-profiles.json`
   into the agent SQLite store (`openclaw-agent.sqlite` — tables
   `auth_profile_store` and `auth_profile_state`) and rename the JSON files
   to `*.sqlite-import.<ts>.bak`. So those `readJSON` calls miss too.

The chain fell through to Priority 4 (the inline `apiKey` literal in
`models.json`), which on the affected setup is a placeholder string —
hence the 401 from the upstream service.

## Fix

Switch Priority 1 to the **provider-string** overload:

```js
api.runtime.modelAuth.resolveApiKeyForProvider({ provider, cfg })
```

That call only needs the provider name (which we already resolved via
`findModelProviderConfig`) and tells OpenClaw to walk its **own** full auth
chain, including the SQLite-backed profile store. `cfg` comes from
`api.runtime.config.current()` (now defensively optional-chained in case the
runtime proxy hasn't materialized that subsystem yet).

Also surface success/failure on this path with provider context and the
resolved `source` / `mode`, so any future regression on this path is visible
in logs instead of silently dropping to the legacy fallbacks.

## Scope kept minimal

Priority 2/3/4 are intentionally **unchanged** for back-compat with older
OpenClaw installs and standalone CLI usage that doesn't carry `api.runtime`.

## Verification

- `node --test utils/ai.test.js` — **29/29 pass**
- `npm test` — **5/5 pass**
- Manually verified the new log line surfaces source/mode on a real
  `resolveApiKeyForProvider` resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)